### PR TITLE
Small typo in dimensional stacking?

### DIFF
--- a/docs/source/indepth_tutorial/open-exploration.ipynb
+++ b/docs/source/indepth_tutorial/open-exploration.ipynb
@@ -557,7 +557,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see from this visual that if B is high, while Q is low, we have a high concentration of cases where pollution stays below 0.8. The mean and stdev have some limited additional influence. By playing around with an alternative number of bins, or different number of layers, patterns can be coarsened or refined. \n",
+    "We can see from this visual that if B is high, while Q is high, we have a high concentration of cases where pollution stays below 0.8. The mean and stdev have some limited additional influence. By playing around with an alternative number of bins, or different number of layers, patterns can be coarsened or refined. \n",
     "\n",
     "### regional sensitivity analysis\n",
     "\n",


### PR DESCRIPTION
The figure in cell [13] has a high concentration where `b == 2` and `q == 2`, so I interpret this to mean Q needs to be "high", rather than low?

![](https://user-images.githubusercontent.com/6628281/58382557-13937e80-7fcc-11e9-9d23-e446d43b579c.png)