### PR TITLE
Info on incompatible package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ nbsphinx
 future
 futures
 numpy
-scipy
-pandas
+scipy==1.2.*
+pandas>=0.24.*
 ipython
 ipyparallel
 JPype1


### PR DESCRIPTION
Adding in the hope that it will save someone time debugging. Most changes are in 3b05c3a.

### Incompatible package versions:
`scipy 1.3.*`
Error: cannot import name 'factorial' from 'scipy.misc' (/usr/local/lib/python3.7/site-packages/scipy/misc/__init__.py)

`pandas 0.23.*`
I believe this was addressed in da5421c?