### PR TITLE
update IntegerParameter

### DIFF
--- a/ema_workbench/em_framework/parameters.py
+++ b/ema_workbench/em_framework/parameters.py
@@ -193,9 +193,9 @@ class IntegerParameter(Parameter):
         if lower bound is larger than upper bound
     ValueError
         if entries in resolution are outside range of lower_bound and
-        upper_bound, or not an numbers.Integral instance
+        upper_bound, or not an integer instance
     ValueError
-        if lower_bound or upper_bound is not an numbers.Integral instance
+        if lower_bound or upper_bound is not an integer instance
 
     '''
 
@@ -212,16 +212,21 @@ class IntegerParameter(Parameter):
             variable_name=variable_name,
             pff=pff)
 
-        lb_int = isinstance(lower_bound, numbers.Integral)
-        up_int = isinstance(upper_bound, numbers.Integral)
+        lb_int = float(lower_bound).is_integer()
+        up_int = float(upper_bound).is_integer()
 
-        if not (lb_int or up_int):
+        if not (lb_int and up_int):
             raise ValueError('lower bound and upper bound must be integers')
+            
+        self.lower_bound = int(lower_bound)
+        self.upper_bound = int(upper_bound)
 
-        for entry in self.resolution:
-            if not isinstance(entry, numbers.Integral):
+        for idx, entry in enumerate(self.resolution):
+            if not float(entry).is_integer():
                 raise ValueError(('all entries in resolution should be '
                                   'integers'))
+            else:
+                self.resolution[idx] = int(entry)
 
         self.dist = Parameter.INTEGER
 


### PR DESCRIPTION
Suggestion to also accept float values that are verified integers. long() and int() are unified in python 3 and therefore the use of the integer instance shouldn't be a problem in comparison to the numbers.Integral instance? This suggestion makes it possible to use real and int parameters in the create_parameters function when loading a csv-file. This was/is causing issues as integers are transformed to floats when the bound values of these parameters where mixed.