### PR TITLE
update vensim_example.py

### DIFF
--- a/ema_workbench/examples/vensim_example.py
+++ b/ema_workbench/examples/vensim_example.py
@@ -23,10 +23,12 @@ if __name__ == "__main__":
     # instantiate a model
     wd = r'./models/vensim example'
     vensimModel = VensimModel("simpleModel", wd=wd,
-                              model_file=r'\model.vpm')
+                              model_file=r'model.vpm') 
+                  # use 'model.vpmx' for 64bit version
+                  # can be created with Vensim
     vensimModel.uncertainties = [RealParameter("x11", 0, 2.5),
                                  RealParameter("x12", -2.5, 2.5)]
 
     vensimModel.outcomes = [TimeSeriesOutcome('a')]
 
-    results = perform_experiments(vensimModel, 1000, parallel=True)
+    results = perform_experiments(vensimModel, 1000)


### PR DESCRIPTION
1) line 26: deleted "\" in "model_file=r'\model.vpm'" due to changes in the os.path.join() method, which led to errors generating the absolute path
2) added lines 27, 28: comment for alternative model format to use with 64 bit Vensim & Python versions
3) line 34: deleted ", parallel=True", which produced an error that the key word argument 'parallel' would not exist