### PR TITLE
Tiny typo in vensimDLL logging output

### DIFF
--- a/ema_workbench/connectors/vensimDLLwrapper.py
+++ b/ema_workbench/connectors/vensimDLLwrapper.py
@@ -90,7 +90,7 @@ else:
         _logger.info('using single precision vensim')
     elif vensim_double:
         vensim = vensim_double
-        _logger.info('using single precision vensim')
+        _logger.info('using double precision vensim')
 
 del sys, struct
 


### PR DESCRIPTION
Teeny tiny typo, I think, that caused a bit of confusion when debugging for #96 previously.