### PR TITLE
WIP: KDE pairplot in PRIM analysis

### DIFF
--- a/ema_workbench/analysis/prim.py
+++ b/ema_workbench/analysis/prim.py
@@ -765,15 +765,17 @@ class PrimBox(object):
 
         '''
         return sdutil.plot_tradeoff(self.peeling_trajectory, cmap=cmap)
-
-    def show_pairs_scatter(self, i=None):
-        ''' Make a pair wise scatter plot of all the restricted
+    
+    def show_pair_plot(self, i=None, kind='scatter'):
+        ''' Make a pair wise scatter or contour plot of all the restricted
         dimensions with color denoting whether a given point is of
         interest or not and the boxlims superimposed on top.
 
         Parameters
         ----------
         i : int, optional
+        kind: str, optional
+            'scatter' (default) or 'kde' (contour)
 
         Returns
         -------
@@ -786,11 +788,18 @@ class PrimBox(object):
         resdim = sdutil._determine_restricted_dims(self.box_lims[i],
                                                    self.prim.box_init)
 
-        return sdutil.plot_pair_wise_scatter(self.prim.x.iloc[self.yi_initial,:],
+        return sdutil.plot_pair_wise(self.prim.x.iloc[self.yi_initial,:],
                                              self.prim.y[self.yi_initial],
                                              self.box_lims[i],
                                              self.prim.box_init,
-                                             resdim)
+                                             resdim,
+                                             kind)
+
+    def show_pairs_scatter(self, i=None):
+        '''
+        Calls `show_pair_plot()`. Included for backwards compatibility.
+        '''
+        return show_pair_plot(self, i)
 
     def write_ppt_to_stdout(self):
         '''write the peeling and pasting trajectory to stdout'''

--- a/ema_workbench/analysis/scenario_discovery_util.py
+++ b/ema_workbench/analysis/scenario_discovery_util.py
@@ -314,7 +314,7 @@ def _calculate_quasip(x, y, box, Hbox, Tbox):
     return qp
 
 
-def plot_pair_wise_scatter(x, y, boxlim, box_init, restricted_dims):
+def plot_pair_wise(x, y, boxlim, box_init, restricted_dims, kind):
     ''' helper function for pair wise scatter plotting
 
     Parameters
@@ -328,6 +328,8 @@ def plot_pair_wise_scatter(x, y, boxlim, box_init, restricted_dims):
     box_init : DataFrame
     restricted_dims : collection of strings
                       list of uncertainties that define the boxlims
+    kind : str
+        'scatter' or 'kde'
 
     '''
 
@@ -358,7 +360,7 @@ def plot_pair_wise_scatter(x, y, boxlim, box_init, restricted_dims):
         data[column] = data[column].cat.codes
 
     data['y'] = y  # for testing
-    grid = sns.pairplot(data=data, hue='y', vars=x.columns.values)
+    grid = sns.pairplot(data=data, hue='y', vars=x.columns.values, kind=kind)
 
     cats = set(categorical_columns)
     for row, ylabel in zip(grid.axes, grid.y_vars):


### PR DESCRIPTION
Resolves #98 to allow users to plot a contour map in addition to the scatter currently offered by `PrimBox.show_pairs_scatter()`.

This is currently implemented as a parameter that defaults to 'scatter' but could also be implemented using **kwargs.