### PR TITLE
update utilities.experiments_to_scenarios to datafames

### DIFF
--- a/ema_workbench/util/utilities.py
+++ b/ema_workbench/util/utilities.py
@@ -194,10 +194,10 @@ def save_results(results, file_name):
     _logger.info("results saved successfully to {}".format(file_name))
 
 
-def experiments_to_scenarios(experiments, model=None):
+def experiments_to_scenarios(experiments: pd.DataFrame, model=None):
     """
 
-    This function transform a structured experiments array into a list
+    This function transform an experiments dataframe into a list
     of Scenarios.
 
     If model is provided, the uncertainties of the model are used.
@@ -206,8 +206,8 @@ def experiments_to_scenarios(experiments, model=None):
 
     Parameters
     ----------
-    experiments : numpy structured array
-                  a structured array containing experiments
+    experiments : Pandas Dataframe
+                  a DataFrame containing experiments
     model : ModelInstance, optional
 
     Returns
@@ -217,7 +217,7 @@ def experiments_to_scenarios(experiments, model=None):
     """
     # get the names of the uncertainties
     if model is None:
-        uncertainties = [entry[0] for entry in experiments.dtype.descr]
+        uncertainties = [column for column in experiments.columns]
 
         # remove policy and model, leaving only the case related uncertainties
         try:


### PR DESCRIPTION
Hi Jan, 

When trying to rerun experiments using experiments_to_scenarios I found that the format that is expected is not consistent with the format used by ema_workbench.load_results. It expects a structured numpy array while the experiments are returned by load_results as dataframe. I've changed the description, the way of extracting the uncertainty names (now based on simple df.columns) and added type-hinting for the experiments. 

I've tested it in my own setup and it works fine. Let me know if this is okay to change. 

Seth