### PR TITLE
setup.py: Add classifiers and python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,4 +71,10 @@ setup(
     url="https://github.com/quaquel/EMAworkbench",
     license="BSD 3-Clause",
     platforms="Linux, Mac OS X, Windows",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
Adds some PyPI [classifiers](https://pypi.org/classifiers/) with general information about the project and specify python_requires to make sure installers (like pip) only install this version when a compatible Python version is detected.