### PR TITLE
Pyupgrade 3.8: Update syntax with Python 3.8+ features

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,7 @@ def establish_version():
     version_info = ema_workbench.__version__
     version_match = re.search(r"^(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)", version_info)
 
-    return tuple((group for group in version_match.groups()))
+    return tuple(group for group in version_match.groups())
 
 
 version_info = establish_version()

--- a/ema_workbench/analysis/b_and_w_plotting.py
+++ b/ema_workbench/analysis/b_and_w_plotting.py
@@ -89,7 +89,7 @@ def set_ax_lines_bw(ax, colormap, line_style="continuous"):
         try:
             mapping = colormap[orig_color]
         except BaseException:
-            _logger.warning("no mapping specified for color: {}".format(orig_color))
+            _logger.warning(f"no mapping specified for color: {orig_color}")
         else:
             if line_style == "continuous":
                 line.set_color("black")
@@ -148,7 +148,7 @@ def set_ax_collections_to_bw(ax, style, colormap):
         try:
             converter_func = _collection_converter[collection_type]
         except KeyError:
-            raise EMAError("converter for {} not implemented".format(collection_type))
+            raise EMAError(f"converter for {collection_type} not implemented")
         else:
             converter_func(collection, ax, style, colormap)
 
@@ -175,7 +175,7 @@ def _set_ax_polycollection_to_bw(collection, ax, style, colormap):
             try:
                 mapping = colormap[orig_color]
             except BaseException:
-                _logger.warning("no mapping specified for color: {}".format(orig_color))
+                _logger.warning(f"no mapping specified for color: {orig_color}")
             else:
                 new_color = color_converter.to_rgba(mapping["fill"])
                 new_color = np.asarray([new_color])
@@ -187,7 +187,7 @@ def _set_ax_polycollection_to_bw(collection, ax, style, colormap):
         try:
             mapping = colormap[orig_color]
         except BaseException:
-            _logger.warning("no mapping specified for color: {}".format(orig_color))
+            _logger.warning(f"no mapping specified for color: {orig_color}")
         else:
             collection.update({"facecolors": "none"})
             collection.update({"edgecolors": "white"})

--- a/ema_workbench/analysis/feature_scoring.py
+++ b/ema_workbench/analysis/feature_scoring.py
@@ -212,7 +212,7 @@ def get_rf_feature_scores(
         rfc = RandomForestRegressor
         criterion = "mse"
     else:
-        raise ValueError("{} not valid for mode".format(mode))
+        raise ValueError(f"{mode} not valid for mode")
 
     forest = rfc(
         n_estimators=nr_trees,
@@ -318,7 +318,7 @@ def get_ex_feature_scores(
         etc = ExtraTreesRegressor
         criterion = "mse"
     else:
-        raise ValueError("{} not valid for mode".format(mode))
+        raise ValueError(f"{mode} not valid for mode")
 
     extra_trees = etc(
         n_estimators=nr_trees,

--- a/ema_workbench/analysis/logistic_regression.py
+++ b/ema_workbench/analysis/logistic_regression.py
@@ -112,7 +112,7 @@ def contours(ax, model, xlabel, ylabel, levels):
     ax.contourf(Xgrid, Ygrid, Zgrid, levels, cmap=cmap, zorder=0)
 
 
-class Logit(object):
+class Logit:
     """Implements an interactive version of logistic regression using
     BIC based forward selection
 

--- a/ema_workbench/analysis/parcoords.py
+++ b/ema_workbench/analysis/parcoords.py
@@ -125,7 +125,7 @@ def get_limits(data):
     return data.apply(limits)
 
 
-class ParallelAxes(object):
+class ParallelAxes:
     """Base class for creating a parallel axis plot.
 
     Parameters

--- a/ema_workbench/analysis/plotting.py
+++ b/ema_workbench/analysis/plotting.py
@@ -221,7 +221,7 @@ def group_by_envelopes(
         try:
             plot_envelope(ax, j, time, value, fill)
         except ValueError:
-            _logger.exception("value error when plotting for %s" % (key))
+            _logger.exception(f"value error when plotting for {key}")
             raise
 
     if density:
@@ -848,7 +848,7 @@ def multiple_densities(
 
         axes_dict["main plot"] = ax_env
         for n, entry in enumerate(kde_axes):
-            axes_dict["density_%s" % n] = entry
+            axes_dict[f"density_{n}"] = entry
 
             # turn of ticks for all but the first density
             if n > 0:

--- a/ema_workbench/analysis/plotting.py
+++ b/ema_workbench/analysis/plotting.py
@@ -707,7 +707,7 @@ def multiple_densities(
     experiments_to_show=None,
     plot_type=PlotType.ENVELOPE,
     log=False,
-    **kwargs
+    **kwargs,
 ):
     """Make an envelope plot with multiple density plots over the run time
 

--- a/ema_workbench/analysis/plotting_util.py
+++ b/ema_workbench/analysis/plotting_util.py
@@ -167,7 +167,7 @@ def plot_kde(ax, values, log):
             ax.set_xscale("log")
         else:
             ax.set_xticks([int(0), ax.get_xaxis().get_view_interval()[1]])
-            labels = ["{0:.2g}".format(0), "{0:.2g}".format(ax.get_xlim()[1])]
+            labels = [f"{0:.2g}", f"{ax.get_xlim()[1]:.2g}"]
             ax.set_xticklabels(labels)
 
 
@@ -292,7 +292,7 @@ def group_density(
     elif density == Density.BOXENPLOT:
         plot_boxenplot(ax_d, values, log, group_labels=group_labels)
     else:
-        raise EMAError("unknown density type: {}".format(density))
+        raise EMAError(f"unknown density type: {density}")
 
     ax_d.set_xlabel("")
     ax_d.set_ylabel("")
@@ -847,7 +847,7 @@ def do_titles(ax, titles, outcome):
                 ax.set_title(titles[outcome])
             except KeyError:
                 _logger.warning(
-                    "key error in do_titles, no title provided for `%s`" % (outcome)
+                    f"key error in do_titles, no title provided for `{outcome}`"
                 )
                 ax.set_title(outcome)
 
@@ -874,7 +874,7 @@ def do_ylabels(ax, ylabels, outcome):
                 ax.set_ylabel(ylabels[outcome])
             except KeyError:
                 _logger.warning(
-                    "key error in do_ylabels, no ylabel provided for `%s`" % (outcome)
+                    f"key error in do_ylabels, no ylabel provided for `{outcome}`"
                 )
                 ax.set_ylabel(outcome)
 

--- a/ema_workbench/analysis/plotting_util.py
+++ b/ema_workbench/analysis/plotting_util.py
@@ -783,10 +783,7 @@ def prepare_data(
             # no grouping specifier, so infer from the data
             if group_by == "index":
                 raise EMAError(
-                    (
-                        "no grouping specifiers provided while "
-                        "trying to group on index"
-                    )
+                    "no grouping specifiers provided while " "trying to group on index"
                 )
             else:
                 column_to_group_by = experiments[group_by]

--- a/ema_workbench/analysis/prim.py
+++ b/ema_workbench/analysis/prim.py
@@ -126,7 +126,7 @@ def pca_preprocess(experiments, y, subsets=None, exclude=set()):
     for key, value in subsets.items():
         # the names of the rotated columns are based on the group name
         # and an index
-        subset_cols = ["{}_{}".format(key, i) for i in range(len(value))]
+        subset_cols = [f"{key}_{i}" for i in range(len(value))]
         new_columns.extend(subset_cols)
         new_dtypes.extend((float,) * len(value))
 
@@ -155,7 +155,7 @@ def pca_preprocess(experiments, y, subsets=None, exclude=set()):
         j += len(value)
 
         for i in range(len(value)):
-            name = "%s_%s" % (key, i)
+            name = f"{key}_{i}"
             rotated_experiments[name] = subset_experiments[:, i]
             [column_names.append(name)]
 
@@ -202,7 +202,7 @@ def run_constrained_prim(experiments, y, issignificant=True, **kwargs):
     for n in range(1, len(dims) + 1):
         for subset in itertools.combinations(dims, n):
             subsets.append(subset)
-    _logger.info("going to run PRIM {} times".format(len(subsets)))
+    _logger.info(f"going to run PRIM {len(subsets)} times")
 
     boxes = [boxn]
     for subset in subsets:
@@ -440,7 +440,7 @@ class PrimBox(object):
 
         # make the box definition
         columns = pd.MultiIndex.from_product(
-            [["box {}".format(i)], ["min", "max", "qp values"]]
+            [[f"box {i}"], ["min", "max", "qp values"]]
         )
         box_lim = pd.DataFrame(np.zeros((len(uncs), 3)), index=uncs, columns=columns)
 
@@ -667,7 +667,7 @@ class PrimBox(object):
         if len(self._resampled) < iterations:
             with temporary_filter(__name__, INFO, "find_box"):
                 for j in range(len(self._resampled), iterations):
-                    _logger.info("resample {}".format(j))
+                    _logger.info(f"resample {j}")
                     index = np.random.choice(
                         x.index, size=int(x.shape[0] * p), replace=False
                     )
@@ -1686,7 +1686,7 @@ class Prim(sdutil.OutputFormatterMixin):
 
         for key in keys:
             if dtypes[key][0] == np.dtype(object):
-                raise EMAError("%s has dtype object and can thus not be rotated" % key)
+                raise EMAError(f"{key} has dtype object and can thus not be rotated")
         return True
 
     _peels = {"object": _categorical_peel, "int": _discrete_peel, "float": _real_peel}

--- a/ema_workbench/analysis/prim.py
+++ b/ema_workbench/analysis/prim.py
@@ -306,7 +306,7 @@ def setup_prim(results, classify, threshold, incl_unc=[], **kwargs):
     return Prim(x, y, threshold=threshold, mode=mode, **kwargs)
 
 
-class PrimBox(object):
+class PrimBox:
     """A class that holds information for a specific box
 
     Attributes
@@ -723,11 +723,9 @@ class PrimBox(object):
         """
         if self._frozen:
             raise PrimException(
-                (
-                    "box has been frozen because PRIM "
-                    "has found at least one more recent "
-                    "box"
-                )
+                "box has been frozen because PRIM "
+                "has found at least one more recent "
+                "box"
             )
 
         res_dim = sdutil._determine_restricted_dims(

--- a/ema_workbench/analysis/prim_util.py
+++ b/ema_workbench/analysis/prim_util.py
@@ -69,7 +69,7 @@ def get_quantile(data, quantile):
     return value
 
 
-class CurEntry(object):
+class CurEntry:
     """a descriptor for the current entry on the peeling and pasting
     trajectory"""
 
@@ -209,7 +209,7 @@ def box_to_tuple(box):
     return tupled_box
 
 
-class NotSeen(object):
+class NotSeen:
     def __init__(self):
         self.seen = set()
 

--- a/ema_workbench/analysis/regional_sa.py
+++ b/ema_workbench/analysis/regional_sa.py
@@ -36,7 +36,7 @@ def build_legend(x, y):
     for i in range(np.max(y) + 1):
         proxy = plt.Line2D([0, 1], [0, 1], color=cp[i + 1])
         proxies.append(proxy)
-        labels.append("{} (N={})".format(i, x[y == i].shape[0]))
+        labels.append(f"{i} (N={x[y == i].shape[0]})")
     proxies.append(plt.Line2D([0, 1], [0, 1], lw=1, color="darkgrey"))
     labels.append("unconditioned")
     return proxies, labels
@@ -169,7 +169,7 @@ def plot_continuous_cdf(ax, unc, x, y, xticklabels_on, ccdf):
         yvals = np.arange(len(sorted_data)) / float(len(sorted_data))
         if ccdf:
             yvals = 1 - yvals
-        ax.plot(sorted_data, yvals, color=cp[i + 1], label="{}".format(i))
+        ax.plot(sorted_data, yvals, color=cp[i + 1], label=f"{i}")
 
     x0 = x.min()
     x1 = x.max()
@@ -185,7 +185,7 @@ def plot_continuous_cdf(ax, unc, x, y, xticklabels_on, ccdf):
     xticklocs = np.linspace(x0, x1, 4)
     ax.set_xticks(xticklocs)
     if xticklabels_on:
-        ax.set_xticklabels(["{:.2g}".format(entry) for entry in xticklocs])
+        ax.set_xticklabels([f"{entry:.2g}" for entry in xticklocs])
     else:
         ax.set_xticklabels([])
 

--- a/ema_workbench/analysis/scenario_discovery_util.py
+++ b/ema_workbench/analysis/scenario_discovery_util.py
@@ -787,7 +787,7 @@ def plot_boxes(x, boxes, together):
         return figs
 
 
-class OutputFormatterMixin(object):
+class OutputFormatterMixin:
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractproperty

--- a/ema_workbench/analysis/scenario_discovery_util.py
+++ b/ema_workbench/analysis/scenario_discovery_util.py
@@ -600,7 +600,7 @@ def plot_box(
             values = [vi for vi in values if vi != -1]
 
             if len(values) == 1:
-                value = "{:.2g}".format(values[0])
+                value = f"{values[0]:.2g}"
             else:
                 value = "{:.2g}, {:.2g}".format(*values)
             qp_formatted[key] = value
@@ -775,7 +775,7 @@ def plot_boxes(x, boxes, together):
 
         for j, norm_box_lim in enumerate(norm_box_lims):
             fig, ax = _setup_figure(uncs)
-            ax.set_title("box {}".format(j))
+            ax.set_title(f"box {j}")
             color = next(colors)
 
             figs.append(fig)
@@ -813,7 +813,7 @@ class OutputFormatterMixin(object):
         box_lims, uncs = _get_sorted_box_lims(boxes, _make_box(self.x))
         nr_boxes = len(boxes)
         dtype = float
-        index = ["box {}".format(i + 1) for i in range(nr_boxes)]
+        index = [f"box {i + 1}" for i in range(nr_boxes)]
         for value in box_lims[0].dtypes:
             if value == object:
                 dtype = object
@@ -848,7 +848,7 @@ class OutputFormatterMixin(object):
 
         stats = self.stats
 
-        index = pd.Index(["box {}".format(i + 1) for i in range(len(stats))])
+        index = pd.Index([f"box {i + 1}" for i in range(len(stats))])
 
         return pd.DataFrame(stats, index=index)
 

--- a/ema_workbench/connectors/excel.py
+++ b/ema_workbench/connectors/excel.py
@@ -192,7 +192,7 @@ class BaseExcelModel(FileModel):
                 self.wb.Close(False)
             except com_error as err:
                 _logger.warning(
-                    "com error on wb.Close: {}".format(err),
+                    f"com error on wb.Close: {err}",
                 )
             del self.wb
         if self.xl:
@@ -201,7 +201,7 @@ class BaseExcelModel(FileModel):
                 self.xl.Quit()
             except com_error as err:
                 _logger.warning(
-                    "com error on xl.Quit: {}".format(err),
+                    f"com error on xl.Quit: {err}",
                 )
             del self.xl
 
@@ -230,9 +230,9 @@ class BaseExcelModel(FileModel):
         try:
             sheet = self.wb.Sheets(sheetname)
         except Exception:
-            _logger.warning("com error: sheet '{}' not found".format(sheetname))
+            _logger.warning(f"com error: sheet '{sheetname}' not found")
             _logger.warning(
-                "known sheets: {}".format(", ".join(self.get_wb_sheetnames()))
+                f"known sheets: {', '.join(self.get_wb_sheetnames())}"
             )
             self.cleanup()
             raise
@@ -267,7 +267,7 @@ class BaseExcelModel(FileModel):
             sheet = self.get_sheet(this_sheet)
         except NoDefaultSheetError:
             raise EMAError(
-                "no default sheet while trying to read from '{}'".format(name)
+                f"no default sheet while trying to read from '{name}'"
             )
 
         try:
@@ -310,7 +310,7 @@ class BaseExcelModel(FileModel):
             sheet = self.get_sheet(this_sheet)
         except NoDefaultSheetError:
             raise EMAError(
-                "no default sheet while trying to write to '{}'".format(name)
+                f"no default sheet while trying to write to '{name}'"
             )
 
         try:
@@ -328,7 +328,7 @@ class BaseExcelModel(FileModel):
             try:
                 return [sh.Name for sh in self.wb.Sheets]
             except com_error as err:
-                return ["com_error: {}".format(err)]
+                return [f"com_error: {err}"]
         else:
             return ["error: wb not available"]
 

--- a/ema_workbench/connectors/excel.py
+++ b/ema_workbench/connectors/excel.py
@@ -75,7 +75,7 @@ class BaseExcelModel(FileModel):
     def __init__(
         self, name, wd=None, model_file=None, default_sheet=None, pointers=None
     ):
-        super(BaseExcelModel, self).__init__(name, wd=wd, model_file=model_file)
+        super().__init__(name, wd=wd, model_file=model_file)
         #: Reference to the Excel application. This attribute is `None` until
         #: model_init has been invoked.
         self.xl = None
@@ -113,7 +113,7 @@ class BaseExcelModel(FileModel):
                  arguments.
 
         """
-        super(BaseExcelModel, self).model_init(policy)
+        super().model_init(policy)
 
         if not self.xl:
             try:
@@ -231,9 +231,7 @@ class BaseExcelModel(FileModel):
             sheet = self.wb.Sheets(sheetname)
         except Exception:
             _logger.warning(f"com error: sheet '{sheetname}' not found")
-            _logger.warning(
-                f"known sheets: {', '.join(self.get_wb_sheetnames())}"
-            )
+            _logger.warning(f"known sheets: {', '.join(self.get_wb_sheetnames())}")
             self.cleanup()
             raise
 
@@ -266,9 +264,7 @@ class BaseExcelModel(FileModel):
         try:
             sheet = self.get_sheet(this_sheet)
         except NoDefaultSheetError:
-            raise EMAError(
-                f"no default sheet while trying to read from '{name}'"
-            )
+            raise EMAError(f"no default sheet while trying to read from '{name}'")
 
         try:
             value = sheet.Range(this_range).Value
@@ -309,9 +305,7 @@ class BaseExcelModel(FileModel):
         try:
             sheet = self.get_sheet(this_sheet)
         except NoDefaultSheetError:
-            raise EMAError(
-                f"no default sheet while trying to write to '{name}'"
-            )
+            raise EMAError(f"no default sheet while trying to write to '{name}'")
 
         try:
             sheet.Range(this_range).Value = value

--- a/ema_workbench/connectors/netlogo.py
+++ b/ema_workbench/connectors/netlogo.py
@@ -171,7 +171,7 @@ class BaseNetLogoModel(FileModel):
             try:
                 self.netlogo.command(self.command_format.format(key, value))
             except jpype.JavaException as e:
-                _logger.warning("variable {} throws exception: {}".format(key, str(e)))
+                _logger.warning(f"variable {key} throws exception: {str(e)}")
 
         _logger.debug("model parameters set successfully")
 
@@ -189,10 +189,10 @@ class BaseNetLogoModel(FileModel):
                 self.working_directory, variable, ".txt", os.sep
             )
             fns[variable] = fn
-            fn = '"{}"'.format(fn)
+            fn = f'"{fn}"'
             fn = fn.replace(os.sep, "/")
 
-            if self.netlogo.report("is-agentset? {}".format(variable)):
+            if self.netlogo.report(f"is-agentset? {variable}"):
                 # if name is name of an agentset, we
                 # assume that we should count the total number of agents
                 nc = r"file-open {0} file-write count {1}".format(
@@ -205,7 +205,7 @@ class BaseNetLogoModel(FileModel):
                 nc = r"file-open {0} file-write {1}".format(fn, variable)
             commands.append(nc)
 
-        c_start = "repeat {} [".format(self.run_length)
+        c_start = f"repeat {self.run_length} ["
         c_close = "go ]"
         c_middle = " ".join(commands)
         command = " ".join((c_start, c_middle, c_close))
@@ -227,7 +227,7 @@ class BaseNetLogoModel(FileModel):
             try:
                 data = self.netlogo.report(variable)
             except NetLogoException:
-                _logger.exception("{} not a reporter".format(variable))
+                _logger.exception(f"{variable} not a reporter")
             else:
                 results[variable] = data
 

--- a/ema_workbench/connectors/netlogo.py
+++ b/ema_workbench/connectors/netlogo.py
@@ -112,7 +112,7 @@ class BaseNetLogoModel(FileModel):
         separate working directory prior to calling `model_init`.
 
         """
-        super(BaseNetLogoModel, self).__init__(name, wd=wd, model_file=model_file)
+        super().__init__(name, wd=wd, model_file=model_file)
 
         self.run_length = None
         self.netlogo_home = netlogo_home
@@ -134,7 +134,7 @@ class BaseNetLogoModel(FileModel):
 
 
         """
-        super(BaseNetLogoModel, self).model_init(policy)
+        super().model_init(policy)
         if not hasattr(self, "netlogo"):
             _logger.debug("trying to start NetLogo")
             self.netlogo = pyNetLogo.NetLogoLink(
@@ -195,14 +195,14 @@ class BaseNetLogoModel(FileModel):
             if self.netlogo.report(f"is-agentset? {variable}"):
                 # if name is name of an agentset, we
                 # assume that we should count the total number of agents
-                nc = r"file-open {0} file-write count {1}".format(
+                nc = r"file-open {} file-write count {}".format(
                     fn,
                     variable,
                 )
             else:
                 # it is not an agentset, so assume that it is
                 # a reporter / global variable
-                nc = r"file-open {0} file-write {1}".format(fn, variable)
+                nc = rf"file-open {fn} file-write {variable}"
             commands.append(nc)
 
         c_start = f"repeat {self.run_length} ["

--- a/ema_workbench/connectors/pysd_connector.py
+++ b/ema_workbench/connectors/pysd_connector.py
@@ -49,7 +49,7 @@ class BasePysdModel(AbstractModel):
         if name is None:
             name = pysd.utils.make_python_identifier(mdl_file)[0]
             name = name.replace("_", "")
-        super(BasePysdModel, self).__init__(name)
+        super().__init__(name)
 
     @method_logger(__name__)
     def model_init(self, policy, **kwargs):
@@ -73,7 +73,7 @@ class BasePysdModel(AbstractModel):
         implementation only sets the outputs to an empty dict.
 
         """
-        super(BasePysdModel, self).reset_model()
+        super().reset_model()
         if self.model is not None:
             self.model.initialize()
 

--- a/ema_workbench/connectors/simio_connector.py
+++ b/ema_workbench/connectors/simio_connector.py
@@ -83,7 +83,7 @@ class SimioModel(FileModel, SingleReplication):
             if model_file cannot be found
 
         """
-        super(SimioModel, self).__init__(name, wd=wd, model_file=model_file)
+        super().__init__(name, wd=wd, model_file=model_file)
         assert main_model != None
         self.main_model_name = main_model
         self.output = {}
@@ -97,7 +97,7 @@ class SimioModel(FileModel, SingleReplication):
 
     @method_logger(__name__)
     def model_init(self, policy):
-        super(SimioModel, self).model_init(policy)
+        super().model_init(policy)
         _logger.debug("initializing model")
 
         # get project
@@ -113,10 +113,8 @@ class SimioModel(FileModel, SingleReplication):
 
         if not model:
             raise EMAError(
-                (
-                    f"""main model with name {self.main_model_name} '
+                f"""main model with name {self.main_model_name} '
                             'not found"""
-                )
             )
 
         self.model = SimioAPI.IModel(model)
@@ -174,10 +172,8 @@ class SimioModel(FileModel, SingleReplication):
                 control = self.control_map[key]
             except KeyError:
                 raise EMAError(
-                    (
-                        """uncertainty not specified as '
+                    """uncertainty not specified as '
                                   'control in simio model"""
-                    )
                 )
             else:
                 ret = scenario.SetControlValue(control, str(value))
@@ -204,7 +200,7 @@ class SimioModel(FileModel, SingleReplication):
         implementation only sets the outputs to an empty dict.
 
         """
-        super(SimioModel, self).reset_model()
+        super().reset_model()
 
         self.scenarios.Clear()
         self.output = {}
@@ -222,10 +218,8 @@ class SimioModel(FileModel, SingleReplication):
         scenario = SimioAPI.IScenario(scenario_ended_event.Scenario)
 
         _logger.debug(
-            (
-                f"""scenario {scenario.Name} for experiment '
+            f"""scenario {scenario.Name} for experiment '
                        '{experiment.Name} completed"""
-            )
         )
         responses = experiment.Scenarios.get_Responses()
 
@@ -249,10 +243,8 @@ class SimioModel(FileModel, SingleReplication):
                     )
                 except TypeError:
                     _logger.warning(
-                        (
-                            f"""type error when trying to get a '
+                        f"""type error when trying to get a '
                                              'response for {response.Name}"""
-                        )
                     )
                     raise
 

--- a/ema_workbench/connectors/vensim.py
+++ b/ema_workbench/connectors/vensim.py
@@ -376,7 +376,7 @@ class BaseVensimModel(FileModel):
         error = False
         result_filename = os.path.join(self.working_directory, self.result_file)
         for variable in self.output_variables:
-            _logger.debug("getting data for %s" % variable)
+            _logger.debug(f"getting data for {variable}")
 
             res = get_data(result_filename, variable)
             result, er = check_data(np.asarray(res))
@@ -526,7 +526,7 @@ class LookupUncertainty(Parameter):
             msi._lookup_uncertainties.append(self)
         elif self.lookup_type == "approximation":
             for i, entry in enumerate("A,K,B,Q,M"):
-                name = "{}-{}".format(entry, self.name)
+                name = f"{entry}-{self.name}"
                 msi.uncertainties.append(RealParameter(name, *values[i]))
             msi._lookup_uncertainties.append(self)
         else:

--- a/ema_workbench/connectors/vensim.py
+++ b/ema_workbench/connectors/vensim.py
@@ -154,7 +154,7 @@ def run_simulation(file_name):
         _logger.debug("MENU>RUN|o")
         command("MENU>RUN|o")
     except VensimWarning as w:
-        _logger.warning((str(w)))
+        _logger.warning(str(w))
         raise VensimError(str(w))
 
 
@@ -189,7 +189,7 @@ def get_data(filename, varname, step=1):
 
 def VensimModelStructureInterface(name, wd=None, model_file=None):
     warnings.warn(
-        ("VensimModelStructureInterface is deprecated use " "VensimModel instead")
+        "VensimModelStructureInterface is deprecated use " "VensimModel instead"
     )
 
     return VensimModel(name, wd=wd, model_file=model_file)
@@ -262,7 +262,7 @@ class BaseVensimModel(FileModel):
                 raise ValueError("model file should be a vpm file")
             self._resultfile = "Current.vdf"
 
-        super(BaseVensimModel, self).__init__(name, wd=wd, model_file=model_file)
+        super().__init__(name, wd=wd, model_file=model_file)
         self.outcomes.extend(TimeSeriesOutcome("TIME", variable_name="Time"))
 
         self._lookup_uncertainties = NamedObjectMap(Parameter)
@@ -289,7 +289,7 @@ class BaseVensimModel(FileModel):
         policy : dict
                  policy to be run.
         """
-        super(BaseVensimModel, self).model_init(policy)
+        super().model_init(policy)
 
         fn = os.path.join(self.working_directory, self.model_file)
         load_model(fn)  # load the model
@@ -365,7 +365,7 @@ class BaseVensimModel(FileModel):
         def check_data(result):
             error = False
             if result.shape[0] != self.run_length:
-                data = np.empty((self.run_length))
+                data = np.empty(self.run_length)
                 data[:] = np.NAN
                 data[0 : result.shape[0]] = result
                 result = data
@@ -391,7 +391,7 @@ class BaseVensimModel(FileModel):
         return results
 
     def cleanup(self):
-        super(BaseVensimModel, self).cleanup()
+        super().cleanup()
 
     def reset_model(self):
         """
@@ -399,7 +399,7 @@ class BaseVensimModel(FileModel):
         was called
         """
 
-        super(BaseVensimModel, self).reset_model()
+        super().reset_model()
 
     def _delete_lookup_uncertainties(self):
         """
@@ -493,7 +493,7 @@ class LookupUncertainty(Parameter):
               not needed in case of CAT
 
         """
-        super(LookupUncertainty, self).__init__(values, name)
+        super().__init__(values, name)
         self.lookup_type = lookup_type
         self.y_min = ymin
         self.y_max = ymax

--- a/ema_workbench/connectors/vensimDLLwrapper.py
+++ b/ema_workbench/connectors/vensimDLLwrapper.py
@@ -1,4 +1,4 @@
-"""
+r"""
 
 this is a first draft for wrapping the vensim dll in a pythonic way
 
@@ -51,21 +51,21 @@ try:
     vensim_single = ctypes.windll.vendll32
 except AttributeError:
     vensim_single = None
-except WindowsError:
+except OSError:
     vensim_single = None
 
 try:
-    vensim_double = ctypes.windll.LoadLibrary("C:\Windows\SysWOW64\VdpDLL32.dll")
+    vensim_double = ctypes.windll.LoadLibrary(r"C:\Windows\SysWOW64\VdpDLL32.dll")
 except AttributeError:
     vensim_double = None
-except WindowsError:
+except OSError:
     vensim_double = None
 
 try:
     vensim_64 = ctypes.windll.vendll64
 except AttributeError:
     vensim_64 = None
-except WindowsError:
+except OSError:
     vensim_64 = None
 
 if struct.calcsize("P") * 8 == 64:
@@ -343,7 +343,7 @@ def get_varattrib(varname, attribute):
 
 
 def get_varnames(filter="*", vartype=0):  # @ReservedAssignment
-    """
+    r"""
     This function returns variable names in the model a filter can be specified
     in the same way as Vensim variable Selection filter  (use * for all),
     vartype is an integer that specifies the types of variables you want to
@@ -527,5 +527,5 @@ def use_double_precision():
     global vensim
     try:
         vensim = ctypes.windll.LoadLibrary(r"C:\Windows\SysWOW64\VdpDLL32.dll")
-    except WindowsError:
+    except OSError:
         raise EMAError("double precision vensim dll not found")

--- a/ema_workbench/em_framework/callbacks.py
+++ b/ema_workbench/em_framework/callbacks.py
@@ -75,9 +75,7 @@ class AbstractCallback(ProgressTrackingMixIn, metaclass=abc.ABCMeta):
         reporting_frequency=10,
         log_progress=False,
     ):
-        super(AbstractCallback, self).__init__(
-            nr_experiments, reporting_frequency, _logger, log_progress
-        )
+        super().__init__(nr_experiments, reporting_frequency, _logger, log_progress)
 
         if reporting_interval is None:
             reporting_interval = max(
@@ -103,7 +101,7 @@ class AbstractCallback(ProgressTrackingMixIn, metaclass=abc.ABCMeta):
                   the outcomes dict
 
         """
-        super(AbstractCallback, self).__call__(1)
+        super().__call__(1)
 
     @abc.abstractmethod
     def get_results(self):
@@ -160,7 +158,7 @@ class DefaultCallback(AbstractCallback):
                        tqdm progress bar.
 
         """
-        super(DefaultCallback, self).__init__(
+        super().__init__(
             uncs,
             levers,
             outcomes,
@@ -276,7 +274,7 @@ class DefaultCallback(AbstractCallback):
                 the outcomes dict
 
         """
-        super(DefaultCallback, self).__call__(experiment, outcomes)
+        super().__call__(experiment, outcomes)
 
         # store the case
         self._store_case(experiment)
@@ -321,7 +319,7 @@ class FileBasedCallback(AbstractCallback):
         reporting_interval=100,
         reporting_frequency=10,
     ):
-        super(FileBasedCallback, self).__init__(
+        super().__init__(
             uncs,
             levers,
             outcomes,
@@ -400,7 +398,7 @@ class FileBasedCallback(AbstractCallback):
                 the outcomes dict
 
         """
-        super(FileBasedCallback, self).__call__(experiment, outcomes)
+        super().__call__(experiment, outcomes)
 
         # store the case
         self._store_case(experiment)

--- a/ema_workbench/em_framework/ema_ipyparallel.py
+++ b/ema_workbench/em_framework/ema_ipyparallel.py
@@ -49,7 +49,7 @@ class EngingeLoggerAdapter(logging.LoggerAdapter):
         self.topic = topic
 
     def process(self, msg, kwargs):
-        msg = "{topic}::{msg}".format(topic=self.topic, msg=msg)
+        msg = f"{self.topic}::{msg}"
         return msg, kwargs
 
 
@@ -175,7 +175,7 @@ class LogWatcher(LoggingConfigurable):
     loop = Instance("tornado.ioloop.IOLoop")  # @UndefinedVariable
 
     def _url_default(self):
-        return "tcp://%s:20202" % localhost()
+        return f"tcp://{localhost()}:20202"
 
     def _context_default(self):
         return zmq.Context.instance()
@@ -207,7 +207,7 @@ class LogWatcher(LoggingConfigurable):
             self.stream.setsockopt(zmq.SUBSCRIBE, b"")  # @UndefinedVariable
         else:
             for topic in self.topics:
-                self.log.debug("Subscribing to: %r" % (topic))
+                self.log.debug(f"Subscribing to: {topic!r}")
                 # @UndefinedVariable
                 self.stream.setsockopt(zmq.SUBSCRIBE, topic)
 
@@ -231,7 +231,7 @@ class LogWatcher(LoggingConfigurable):
         raw = [r.decode("utf-8") for r in raw]
 
         if len(raw) != 2 or "." not in raw[0]:
-            logging.getLogger().error("Invalid log message: %s" % raw)
+            logging.getLogger().error(f"Invalid log message: {raw}")
             return
         else:
             topic, msg = raw
@@ -247,7 +247,7 @@ class LogWatcher(LoggingConfigurable):
             if msg[-1] == "\n":
                 msg = msg[:-1]
 
-            log.log(level, "[%s] %s" % (main_topic, msg))
+            log.log(level, f"[{main_topic}] {msg}")
 
 
 class Engine(object):
@@ -264,11 +264,11 @@ class Engine(object):
     """
 
     def __init__(self, engine_id, msis, cwd):
-        _logger.debug("starting engine {}".format(engine_id))
+        _logger.debug(f"starting engine {engine_id}")
         self.engine_id = engine_id
         self.msis = msis
 
-        _logger.debug("setting root working directory to {}".format(cwd))
+        _logger.debug(f"setting root working directory to {cwd}")
         os.chdir(cwd)
 
         models = NamedObjectMap(AbstractModel)

--- a/ema_workbench/em_framework/ema_ipyparallel.py
+++ b/ema_workbench/em_framework/ema_ipyparallel.py
@@ -73,7 +73,7 @@ def start_logwatcher():
         logwatcher.start()
         try:
             logwatcher.loop.start()
-        except (zmq.error.ZMQError, IOError, OSError):
+        except (zmq.error.ZMQError, OSError):
             _logger.warning("shutting down log watcher")
         except RuntimeError:
             pass
@@ -184,7 +184,7 @@ class LogWatcher(LoggingConfigurable):
         return ioloop.IOLoop.instance()
 
     def __init__(self, **kwargs):
-        super(LogWatcher, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.s = self.context.socket(zmq.SUB)  # @UndefinedVariable
         self.s.bind(self.url)
         self.stream = zmqstream.ZMQStream(self.s, self.loop)
@@ -250,7 +250,7 @@ class LogWatcher(LoggingConfigurable):
             log.log(level, f"[{main_topic}] {msg}")
 
 
-class Engine(object):
+class Engine:
     """class for setting up ema specific stuff on each engine
     also functions as a convenient namespace for workbench
     relevant variables

--- a/ema_workbench/em_framework/ema_multiprocessing.py
+++ b/ema_workbench/em_framework/ema_multiprocessing.py
@@ -134,11 +134,11 @@ def setup_working_directories(models, root_dir):
     # if the dict is not empty
     if wd_by_model:
         # make a directory with the process id as identifier
-        tmpdir_name = "tmp{}".format(os.getpid())
+        tmpdir_name = f"tmp{os.getpid()}"
         tmpdir = os.path.join(root_dir, tmpdir_name)
         os.mkdir(tmpdir)
 
-        _logger.debug("setting up working directory: {}".format(tmpdir))
+        _logger.debug(f"setting up working directory: {tmpdir}")
 
         for key, value in wd_by_model.items():
             # we need a sub directory in the process working directory

--- a/ema_workbench/em_framework/evaluators.py
+++ b/ema_workbench/em_framework/evaluators.py
@@ -89,7 +89,7 @@ class Samplers(enum.Enum):
     MORRIS = MorrisSampler()
 
 
-class BaseEvaluator(object):
+class BaseEvaluator:
     """evaluator for experiments using a multiprocessing pool
 
     Parameters
@@ -107,7 +107,7 @@ class BaseEvaluator(object):
     reporting_frequency = 3
 
     def __init__(self, msis):
-        super(BaseEvaluator, self).__init__()
+        super().__init__()
 
         if isinstance(msis, AbstractModel):
             msis = [msis]
@@ -275,7 +275,7 @@ class BaseEvaluator(object):
 
 class SequentialEvaluator(BaseEvaluator):
     def __init__(self, models, **kwargs):
-        super(SequentialEvaluator, self).__init__(models, **kwargs)
+        super().__init__(models, **kwargs)
 
     def initialize(self):
         pass
@@ -314,7 +314,7 @@ class MultiprocessingEvaluator(BaseEvaluator):
     """
 
     def __init__(self, msis, n_processes=None, maxtasksperchild=None, **kwargs):
-        super(MultiprocessingEvaluator, self).__init__(msis, **kwargs)
+        super().__init__(msis, **kwargs)
 
         self._pool = None
         self.n_processes = n_processes
@@ -365,7 +365,7 @@ class MultiprocessingEvaluator(BaseEvaluator):
             self._pool.terminate()
             return False
 
-        super(MultiprocessingEvaluator, self).__exit__(exc_type, exc_value, traceback)
+        super().__exit__(exc_type, exc_value, traceback)
 
     def finalize(self):
         # Stop accepting new jobs and wait for pending jobs to finish.
@@ -384,7 +384,7 @@ class IpyparallelEvaluator(BaseEvaluator):
     """evaluator for using an ipypparallel pool"""
 
     def __init__(self, msis, client, **kwargs):
-        super(IpyparallelEvaluator, self).__init__(msis, **kwargs)
+        super().__init__(msis, **kwargs)
         self.client = client
 
     def initialize(self):
@@ -483,7 +483,7 @@ def perform_experiments(
 
     if not scenarios and not policies:
         raise EMAError(
-            ("no experiments possible since both " "scenarios and policies are 0")
+            "no experiments possible since both " "scenarios and policies are 0"
         )
 
     scenarios, uncertainties, n_scenarios = setup_scenarios(
@@ -691,10 +691,8 @@ def optimize(
     """
     if searchover not in ("levers", "uncertainties"):
         raise EMAError(
-            (
-                "searchover should be one of 'levers' or"
-                "'uncertainties' not {}".format(searchover)
-            )
+            "searchover should be one of 'levers' or"
+            "'uncertainties' not {}".format(searchover)
         )
 
     try:
@@ -702,7 +700,7 @@ def optimize(
             models = models[0]
         else:
             raise NotImplementedError(
-                ("optimization over multiple" "models yet supported")
+                "optimization over multiple" "models yet supported"
             )
     except TypeError:
         pass

--- a/ema_workbench/em_framework/experiment_runner.py
+++ b/ema_workbench/em_framework/experiment_runner.py
@@ -107,8 +107,7 @@ class ExperimentRunner(object):
             errortype = type(e).__name__
             raise EMAError(
                 (
-                    "exception in run_model"
-                    "\nCaused by: {}: {}".format(errortype, str(e))
+                    f"exception in run_model\nCaused by: {errortype}: {str(e)}"
                 )
             )
 

--- a/ema_workbench/em_framework/experiment_runner.py
+++ b/ema_workbench/em_framework/experiment_runner.py
@@ -13,7 +13,7 @@ __all__ = ["ExperimentRunner"]
 _logger = get_module_logger(__name__)
 
 
-class ExperimentRunner(object):
+class ExperimentRunner:
     """Helper class for running the experiments
 
     This class contains the logic for initializing models properly,
@@ -105,11 +105,7 @@ class ExperimentRunner(object):
             #                 sys.stderr.write("\n")
 
             errortype = type(e).__name__
-            raise EMAError(
-                (
-                    f"exception in run_model\nCaused by: {errortype}: {str(e)}"
-                )
-            )
+            raise EMAError(f"exception in run_model\nCaused by: {errortype}: {str(e)}")
 
         outcomes = model.outcomes_output
         model.reset_model()

--- a/ema_workbench/em_framework/model.py
+++ b/ema_workbench/em_framework/model.py
@@ -152,7 +152,7 @@ class AbstractModel(NamedObject):
                 if par.default is not None:
                     value = par.default
                 else:
-                    _logger.debug("{} not found".format(par.name))
+                    _logger.debug(f"{par.name} not found")
                     continue
 
             multivalue = False
@@ -247,7 +247,7 @@ class AbstractModel(NamedObject):
                     for entry in sorted(field, key=operator.attrgetter("name"))
                 ]
             )
-            return "[{}]".format(joined)
+            return f"[{joined}]"
 
         model_spec = {}
 
@@ -294,7 +294,7 @@ class Replicator(AbstractModel):
             self.nreplications = len(replications)
         else:
             raise TypeError(
-                "replications should be int or list not {}".format(type(replications))
+                f"replications should be int or list not {type(replications)}"
             )
 
     @method_logger(__name__)
@@ -314,7 +314,7 @@ class Replicator(AbstractModel):
         partial_experiment = combine(scenario, self.policy, constants)
 
         for i, rep in enumerate(self.replications):
-            _logger.debug("replication {}".format(i))
+            _logger.debug(f"replication {i}")
             rep.id = i
             experiment = ExperimentReplication(scenario, self.policy, constants, rep)
             output = self.run_experiment(experiment)
@@ -457,7 +457,7 @@ class WorkingDirectoryModel(AbstractModel):
         self.working_directory = wd
 
         if not os.path.exists(self.working_directory):
-            raise ValueError("{} does not exist".format(self.working_directory))
+            raise ValueError(f"{self.working_directory} does not exist")
 
     def as_dict(self):
         model_specs = super(WorkingDirectoryModel, self).as_dict()

--- a/ema_workbench/em_framework/model.py
+++ b/ema_workbench/em_framework/model.py
@@ -95,11 +95,11 @@ class AbstractModel(NamedObject):
         EMAError if name contains non alpha-numerical characters
 
         """
-        super(AbstractModel, self).__init__(name)
+        super().__init__(name)
 
         if not self.name.isalnum():
             raise EMAError(
-                ("name of model should only contain " "alpha numerical characters")
+                "name of model should only contain " "alpha numerical characters"
             )
 
         self._output_variables = None
@@ -307,7 +307,7 @@ class Replicator(AbstractModel):
         policy : Policy instance
 
         """
-        super(Replicator, self).run_model(scenario, policy)
+        super().run_model(scenario, policy)
 
         constants = {c.name: c.value for c in self.constants}
         outputs = defaultdict(list)
@@ -341,7 +341,7 @@ class SingleReplication(AbstractModel):
         policy : Policy instance
 
         """
-        super(SingleReplication, self).run_model(scenario, policy)
+        super().run_model(scenario, policy)
 
         constants = {c.name: c.value for c in self.constants}
 
@@ -384,7 +384,7 @@ class BaseModel(AbstractModel):
     """
 
     def __init__(self, name, function=None):
-        super(BaseModel, self).__init__(name)
+        super().__init__(name)
 
         if not callable(function):
             raise ValueError("function should be callable")
@@ -419,7 +419,7 @@ class BaseModel(AbstractModel):
         return results
 
     def as_dict(self):
-        model_specs = super(BaseModel, self).as_dict()
+        model_specs = super().as_dict()
         model_specs["function"] = self.function
         return model_specs
 
@@ -453,14 +453,14 @@ class WorkingDirectoryModel(AbstractModel):
         ValueError
             if working_directory does not exist
         """
-        super(WorkingDirectoryModel, self).__init__(name)
+        super().__init__(name)
         self.working_directory = wd
 
         if not os.path.exists(self.working_directory):
             raise ValueError(f"{self.working_directory} does not exist")
 
     def as_dict(self):
-        model_specs = super(WorkingDirectoryModel, self).as_dict()
+        model_specs = super().as_dict()
         model_specs["working_directory"] = self.working_directory
         return model_specs
 
@@ -508,7 +508,7 @@ class FileModel(WorkingDirectoryModel):
         experiments
 
         """
-        super(FileModel, self).__init__(name, wd=wd)
+        super().__init__(name, wd=wd)
 
         path_to_file = os.path.join(self.working_directory, model_file)
         if not os.path.isfile(path_to_file):
@@ -516,16 +516,14 @@ class FileModel(WorkingDirectoryModel):
 
         if os.getcwd() == self.working_directory:
             raise ValueError(
-                (
-                    "the working directory of the model cannot be "
-                    "the same as the current working directory"
-                )
+                "the working directory of the model cannot be "
+                "the same as the current working directory"
             )
 
         self.model_file = model_file
 
     def as_dict(self):
-        model_specs = super(FileModel, self).as_dict()
+        model_specs = super().as_dict()
         model_specs["model_file"] = self.model_file
         return model_specs
 

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -554,7 +554,7 @@ class ArchiveLogger(AbstractConvergenceMetric):
     def __call__(self, optimizer):
         self.index += 1
 
-        fn = os.path.join(self.directory, "{}_{}.csv".format(self.base, self.index))
+        fn = os.path.join(self.directory, f"{self.base}_{self.index}.csv")
 
         archive = to_dataframe(optimizer, self.decision_varnames, self.outcome_varnames)
         archive.to_csv(fn)

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -55,28 +55,28 @@ try:
 except ImportError:
     warnings.warn("platypus based optimization not available", ImportWarning)
 
-    class PlatypusProblem(object):
+    class PlatypusProblem:
         constraints = []
 
         def __init__(self, *args, **kwargs):
             pass
 
-    class Variator(object):
+    class Variator:
         def __init__(self, *args, **kwargs):
             pass
 
-    class RandomGenerator(object):
+    class RandomGenerator:
         def __call__(self, *args, **kwargs):
             pass
 
-    class TournamentSelector(object):
+    class TournamentSelector:
         def __init__(self, *args, **kwargs):
             pass
 
         def __call__(self, *args, **kwargs):
             pass
 
-    class EpsilonProgressContinuation(object):
+    class EpsilonProgressContinuation:
         pass
 
     EpsNSGAII = None
@@ -113,9 +113,7 @@ class Problem(PlatypusProblem):
         if constraints is None:
             constraints = []
 
-        super(Problem, self).__init__(
-            len(parameters), len(outcome_names), nconstrs=len(constraints)
-        )
+        super().__init__(len(parameters), len(outcome_names), nconstrs=len(constraints))
         #         assert len(parameters) == len(parameter_names)
         assert searchover in ("levers", "uncertainties", "robust")
 
@@ -141,9 +139,7 @@ class RobustProblem(Problem):
     def __init__(
         self, parameters, outcome_names, scenarios, robustness_functions, constraints
     ):
-        super(RobustProblem, self).__init__(
-            "robust", parameters, outcome_names, constraints
-        )
+        super().__init__("robust", parameters, outcome_names, constraints)
         assert len(robustness_functions) == len(outcome_names)
         self.scenarios = scenarios
         self.robustness_functions = robustness_functions
@@ -177,7 +173,7 @@ def to_problem(model, searchover, reference=None, constraints=None):
 
     if not outcomes:
         raise EMAError(
-            ("no outcomes specified to optimize over, " "all outcomes are of kind=INFO")
+            "no outcomes specified to optimize over, " "all outcomes are of kind=INFO"
         )
 
     problem = Problem(
@@ -216,7 +212,7 @@ def to_robust_problem(model, scenarios, robustness_functions, constraints=None):
 
     if not outcomes:
         raise EMAError(
-            ("no outcomes specified to optimize over, " "all outcomes are of kind=INFO")
+            "no outcomes specified to optimize over, " "all outcomes are of kind=INFO"
         )
 
     problem = RobustProblem(
@@ -466,11 +462,11 @@ def _evaluate_constraints(job_experiment, job_outcomes, constraints):
     return job_constraints
 
 
-class AbstractConvergenceMetric(object):
+class AbstractConvergenceMetric:
     """base convergence metric class"""
 
     def __init__(self, name):
-        super(AbstractConvergenceMetric, self).__init__()
+        super().__init__()
         self.name = name
         self.results = []
 
@@ -485,7 +481,7 @@ class EpsilonProgress(AbstractConvergenceMetric):
     """epsilon progress convergence metric class"""
 
     def __init__(self):
-        super(EpsilonProgress, self).__init__("epsilon_progress")
+        super().__init__("epsilon_progress")
 
     def __call__(self, optimizer):
         self.results.append(optimizer.algorithm.archive.improvements)
@@ -511,7 +507,7 @@ class HyperVolume(AbstractConvergenceMetric):
     """
 
     def __init__(self, minimum, maximum):
-        super(HyperVolume, self).__init__("hypervolume")
+        super().__init__("hypervolume")
         self.hypervolume_func = Hypervolume(minimum=minimum, maximum=maximum)
 
     def __call__(self, optimizer):
@@ -544,7 +540,7 @@ class ArchiveLogger(AbstractConvergenceMetric):
     def __init__(
         self, directory, decision_varnames, outcome_varnames, base_filename="archive"
     ):
-        super(ArchiveLogger, self).__init__("archive_logger")
+        super().__init__("archive_logger")
         self.directory = os.path.abspath(directory)
         self.base = base_filename
         self.decision_varnames = decision_varnames
@@ -562,7 +558,7 @@ class ArchiveLogger(AbstractConvergenceMetric):
 
 class OperatorProbabilities(AbstractConvergenceMetric):
     def __init__(self, name, index):
-        super(OperatorProbabilities, self).__init__(name)
+        super().__init__(name)
         self.index = index
 
     def __call__(self, optimizer):
@@ -576,7 +572,7 @@ class OperatorProbabilities(AbstractConvergenceMetric):
 class Convergence(ProgressTrackingMixIn):
     """helper class for tracking convergence of optimization"""
 
-    valid_metrics = set(["hypervolume", "epsilon_progress", "archive_logger"])
+    valid_metrics = {"hypervolume", "epsilon_progress", "archive_logger"}
 
     def __init__(
         self,
@@ -586,7 +582,7 @@ class Convergence(ProgressTrackingMixIn):
         logging_freq=5,
         log_progress=False,
     ):
-        super(Convergence, self).__init__(
+        super().__init__(
             max_nfe,
             logging_freq,
             _logger,
@@ -616,7 +612,7 @@ class Convergence(ProgressTrackingMixIn):
         optimizer,
     ):
         nfe = optimizer.algorithm.nfe
-        super(Convergence, self).__call__(nfe - self.i)
+        super().__call__(nfe - self.i)
 
         self.generation += 1
 
@@ -642,7 +638,7 @@ class Convergence(ProgressTrackingMixIn):
 
 class CombinedVariator(Variator):
     def __init__(self, crossover_prob=0.5, mutation_prob=1):
-        super(CombinedVariator, self).__init__(2)
+        super().__init__(2)
         self.SBX = platypus.SBX()
         self.crossover_prob = crossover_prob
         self.mutation_prob = mutation_prob
@@ -885,7 +881,7 @@ def _optimize(
         return results, convergence
 
 
-class BORGDefaultDescriptor(object):
+class BORGDefaultDescriptor:
     # this treats defaults as class level attributes!
 
     def __init__(self, default_function):
@@ -994,7 +990,7 @@ class GenerationalBorg(EpsilonProgressContinuation):
 
         variator = Multimethod(self, variators)
 
-        super(GenerationalBorg, self).__init__(
+        super().__init__(
             NSGAII(
                 problem,
                 population_size,

--- a/ema_workbench/em_framework/outcomes.py
+++ b/ema_workbench/em_framework/outcomes.py
@@ -207,12 +207,12 @@ class AbstractOutcome(Variable):
         klass = self.__class__.__name__
         name = self.name
 
-        rep = "{}('{}'".format(klass, name)
+        rep = f"{klass}('{name}'"
 
         if self.variable_name != [self.name]:
-            rep += ", variable_name={}".format(self.variable_name)
+            rep += f", variable_name={self.variable_name}"
         if self.function:
-            rep += ", function={}".format(self.function)
+            rep += f", function={self.function}"
 
         rep += ")"
 
@@ -300,7 +300,7 @@ class ScalarOutcome(AbstractOutcome):
     def expected_range(self):
         if self._expected_range is None:
             raise ValueError(
-                "no expected_range is set for {}".format(self.variable_name)
+                f"no expected_range is set for {self.variable_name}"
             )
         return self._expected_range
 
@@ -409,7 +409,7 @@ class ArrayOutcome(AbstractOutcome):
     def process(self, values):
         values = super(ArrayOutcome, self).process(values)
         if not isinstance(values, collections.abc.Iterable):
-            raise EMAError("outcome {} should be a collection".format(self.name))
+            raise EMAError(f"outcome {self.name} should be a collection")
         return values
 
     @classmethod
@@ -605,7 +605,7 @@ def create_outcomes(outcomes, **kwargs):
 
     for entry in ["name", "type"]:
         if entry not in outcomes.columns:
-            raise ValueError("no {} column in dataframe".format(entry))
+            raise ValueError(f"no {entry} column in dataframe")
 
     temp_outcomes = []
     for _, row in outcomes.iterrows():

--- a/ema_workbench/em_framework/outcomes.py
+++ b/ema_workbench/em_framework/outcomes.py
@@ -51,7 +51,7 @@ class Register:
             self.outcomes[outcome.name] = outcome.__class__
         elif not isinstance(outcome, self.outcomes[outcome.name]):
             raise ValueError(
-                ("outcome with this name but of different class " "already exists")
+                "outcome with this name but of different class " "already exists"
             )
         else:
             pass  # multiple instances of the same class and name is fine
@@ -74,7 +74,7 @@ class Register:
             stream, extension = self.outcomes[name].to_disk(values)
         except KeyError:
             _logger.warning(
-                ("outcome not defined, falling back on " "ArrayOutcome.to_disk")
+                "outcome not defined, falling back on " "ArrayOutcome.to_disk"
             )
             stream, extension = ArrayOutcome.to_disk(values)
 
@@ -134,7 +134,7 @@ class AbstractOutcome(Variable):
         expected_range=None,
         shape=None,
     ):
-        super(AbstractOutcome, self).__init__(name)
+        super().__init__(name)
 
         if function is not None and not callable(function):
             raise ValueError("function must be a callable")
@@ -187,7 +187,7 @@ class AbstractOutcome(Variable):
         else:
             if len(values) > 1:
                 raise EMAError(
-                    ("more than one value returned without " "processing function")
+                    "more than one value returned without " "processing function"
                 )
 
             return values[0]
@@ -220,7 +220,7 @@ class AbstractOutcome(Variable):
 
     def __hash__(self):
         items = [self.name, self._variable_name, self._expected_range, self.shape]
-        items = tuple([entry for entry in items if entry is not None])
+        items = tuple(entry for entry in items if entry is not None)
 
         return hash(items)
 
@@ -299,9 +299,7 @@ class ScalarOutcome(AbstractOutcome):
     @property
     def expected_range(self):
         if self._expected_range is None:
-            raise ValueError(
-                f"no expected_range is set for {self.variable_name}"
-            )
+            raise ValueError(f"no expected_range is set for {self.variable_name}")
         return self._expected_range
 
     @expected_range.setter
@@ -316,19 +314,15 @@ class ScalarOutcome(AbstractOutcome):
         function=None,
         expected_range=None,
     ):
-        super(ScalarOutcome, self).__init__(
-            name, kind, variable_name=variable_name, function=function
-        )
+        super().__init__(name, kind, variable_name=variable_name, function=function)
         self.expected_range = expected_range
 
     def process(self, values):
-        values = super(ScalarOutcome, self).process(values)
+        values = super().process(values)
         if not isinstance(values, numbers.Number):
             raise EMAError(
-                (
-                    f"outcome {self.name} should be a scalar, but is"
-                    f" {type(values)}: {values}"
-                )
+                f"outcome {self.name} should be a scalar, but is"
+                f" {type(values)}: {values}"
             )
         return values
 
@@ -398,7 +392,7 @@ class ArrayOutcome(AbstractOutcome):
     def __init__(
         self, name, variable_name=None, function=None, expected_range=None, shape=None
     ):
-        super(ArrayOutcome, self).__init__(
+        super().__init__(
             name,
             variable_name=variable_name,
             function=function,
@@ -407,7 +401,7 @@ class ArrayOutcome(AbstractOutcome):
         )
 
     def process(self, values):
-        values = super(ArrayOutcome, self).process(values)
+        values = super().process(values)
         if not isinstance(values, collections.abc.Iterable):
             raise EMAError(f"outcome {self.name} should be a collection")
         return values
@@ -489,7 +483,7 @@ class TimeSeriesOutcome(ArrayOutcome):
     def __init__(
         self, name, variable_name=None, function=None, expected_range=None, shape=None
     ):
-        super(TimeSeriesOutcome, self).__init__(
+        super().__init__(
             name,
             variable_name=variable_name,
             function=function,
@@ -568,7 +562,7 @@ class Constraint(ScalarOutcome):
 
         variable_names = parameter_names + outcome_names
 
-        super(Constraint, self).__init__(
+        super().__init__(
             name,
             kind=AbstractOutcome.INFO,
             variable_name=variable_names,
@@ -579,7 +573,7 @@ class Constraint(ScalarOutcome):
         self.outcome_names = outcome_names
 
     def process(self, values):
-        value = super(Constraint, self).process(values)
+        value = super().process(values)
         assert value >= 0
         return value
 

--- a/ema_workbench/em_framework/parameters.py
+++ b/ema_workbench/em_framework/parameters.py
@@ -75,7 +75,7 @@ class Constant(NamedObject):
         self.value = value
 
     def __repr__(self, *args, **kwargs):
-        return "{}('{}', {})".format(self.__class__.__name__, self.name, self.value)
+        return f"{self.__class__.__name__}('{self.name}', {self.value})"
 
 
 class Category(Constant):

--- a/ema_workbench/em_framework/parameters.py
+++ b/ema_workbench/em_framework/parameters.py
@@ -71,7 +71,7 @@ class Constant(NamedObject):
     """
 
     def __init__(self, name, value):
-        super(Constant, self).__init__(name)
+        super().__init__(name)
         self.value = value
 
     def __repr__(self, *args, **kwargs):
@@ -80,7 +80,7 @@ class Constant(NamedObject):
 
 class Category(Constant):
     def __init__(self, name, value):
-        super(Category, self).__init__(name, value)
+        super().__init__(name, value)
 
 
 def create_category(cat):
@@ -140,7 +140,7 @@ class Parameter(Variable, metaclass=abc.ABCMeta):
         variable_name=None,
         pff=False,
     ):
-        super(Parameter, self).__init__(name)
+        super().__init__(name)
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
         self.resolution = resolution
@@ -237,7 +237,7 @@ class RealParameter(Parameter):
         variable_name=None,
         pff=False,
     ):
-        super(RealParameter, self).__init__(
+        super().__init__(
             name,
             lower_bound,
             upper_bound,
@@ -255,7 +255,7 @@ class RealParameter(Parameter):
     def from_dist(cls, name, dist, **kwargs):
         if not isinstance(dist.dist, sp.stats.rv_continuous):  # @UndefinedVariable
             raise ValueError("dist should be instance of rv_continouos")
-        return super(RealParameter, cls).from_dist(name, dist, **kwargs)
+        return super().from_dist(name, dist, **kwargs)
 
 
 class IntegerParameter(Parameter):
@@ -291,7 +291,7 @@ class IntegerParameter(Parameter):
         variable_name=None,
         pff=False,
     ):
-        super(IntegerParameter, self).__init__(
+        super().__init__(
             name,
             lower_bound,
             upper_bound,
@@ -317,9 +317,7 @@ class IntegerParameter(Parameter):
         try:
             for idx, entry in enumerate(self.resolution):
                 if not float(entry).is_integer():
-                    raise ValueError(
-                        ("all entries in resolution should be " "integers")
-                    )
+                    raise ValueError("all entries in resolution should be " "integers")
                 else:
                     self.resolution[idx] = int(entry)
         except TypeError:
@@ -330,7 +328,7 @@ class IntegerParameter(Parameter):
     def from_dist(cls, name, dist, **kwargs):
         if not isinstance(dist.dist, sp.stats.rv_discrete):  # @UndefinedVariable
             raise ValueError("dist should be instance of rv_discrete")
-        return super(IntegerParameter, cls).from_dist(name, dist, **kwargs)
+        return super().from_dist(name, dist, **kwargs)
 
 
 class CategoricalParameter(IntegerParameter):
@@ -372,7 +370,7 @@ class CategoricalParameter(IntegerParameter):
         if upper_bound == 0:
             raise ValueError("there should be more than 1 category")
 
-        super(CategoricalParameter, self).__init__(
+        super().__init__(
             name,
             lower_bound,
             upper_bound,
@@ -438,7 +436,7 @@ class CategoricalParameter(IntegerParameter):
         # probably need to pass categories as list and zip
         # categories to integers implied by dist
         raise NotImplementedError(
-            ("custom distributions over categories " "not supported yet")
+            "custom distributions over categories " "not supported yet"
         )
 
 
@@ -456,7 +454,7 @@ class BooleanParameter(CategoricalParameter):
     """
 
     def __init__(self, name, default=None, variable_name=None, pff=False):
-        super(BooleanParameter, self).__init__(
+        super().__init__(
             name,
             categories=[True, False],
             default=default,

--- a/ema_workbench/em_framework/points.py
+++ b/ema_workbench/em_framework/points.py
@@ -62,7 +62,7 @@ class Policy(Point):
     #     return [self[param.name] for param in parameters]
 
     def __repr__(self):
-        return "Policy({})".format(super(Policy, self).__repr__())
+        return f"Policy({super(Policy, self).__repr__()})"
 
 
 class Scenario(Point):
@@ -84,7 +84,7 @@ class Scenario(Point):
         super(Scenario, self).__init__(name, Scenario.id_counter(), **kwargs)
 
     def __repr__(self):
-        return "Scenario({})".format(super(Scenario, self).__repr__())
+        return f"Scenario({super(Scenario, self).__repr__()})"
 
 
 class Experiment(NamedObject):
@@ -131,7 +131,7 @@ class ExperimentReplication(NamedDict):
         # this is a unique identifier for an experiment
         # we might also create a better looking name
         self.id = scenario_id * policy_id * replication_id
-        name = "{}_{}_{}".format(scenario.name, policy.name, replication_id)
+        name = f"{scenario.name}_{policy.name}_{replication_id}"
 
         super(ExperimentReplication, self).__init__(
             name, **combine(scenario, policy, constants)
@@ -261,6 +261,6 @@ def experiment_generator(scenarios, model_structures, policies, combine="factori
 
     for i, job in enumerate(jobs):
         msi, policy, scenario = job
-        name = "{} {} {}".format(msi.name, policy.name, i)
+        name = f"{msi.name} {policy.name} {i}"
         experiment = Experiment(name, msi.name, policy, scenario, i)
         yield experiment

--- a/ema_workbench/em_framework/points.py
+++ b/ema_workbench/em_framework/points.py
@@ -34,7 +34,7 @@ class Point(NamedDict):
         if unique_id is None:
             unique_id = Point.id_counter()
 
-        super(Point, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
         self.unique_id = unique_id
 
 
@@ -53,7 +53,7 @@ class Policy(Point):
     id_counter = Counter(1)
 
     def __init__(self, name=None, **kwargs):
-        super(Policy, self).__init__(name, Policy.id_counter(), **kwargs)
+        super().__init__(name, Policy.id_counter(), **kwargs)
 
     # def to_list(self, parameters):
     #     """get list like representation of policy where the
@@ -81,7 +81,7 @@ class Scenario(Point):
     id_counter = Counter(1)
 
     def __init__(self, name=None, **kwargs):
-        super(Scenario, self).__init__(name, Scenario.id_counter(), **kwargs)
+        super().__init__(name, Scenario.id_counter(), **kwargs)
 
     def __repr__(self):
         return f"Scenario({super(Scenario, self).__repr__()})"
@@ -102,7 +102,7 @@ class Experiment(NamedObject):
     """
 
     def __init__(self, name, model_name, policy, scenario, experiment_id):
-        super(Experiment, self).__init__(name)
+        super().__init__(name)
         self.experiment_id = experiment_id
         self.policy = policy
         self.model_name = model_name
@@ -133,9 +133,7 @@ class ExperimentReplication(NamedDict):
         self.id = scenario_id * policy_id * replication_id
         name = f"{scenario.name}_{policy.name}_{replication_id}"
 
-        super(ExperimentReplication, self).__init__(
-            name, **combine(scenario, policy, constants)
-        )
+        super().__init__(name, **combine(scenario, policy, constants))
 
 
 def zip_cycle(*args):

--- a/ema_workbench/em_framework/salib_samplers.py
+++ b/ema_workbench/em_framework/salib_samplers.py
@@ -48,7 +48,7 @@ def get_SALib_problem(uncertainties):
     return problem
 
 
-class SALibSampler(object):
+class SALibSampler:
     def generate_samples(self, uncertainties, size):
         """
         The main method of :class: `~sampler.Sampler` and its
@@ -131,7 +131,7 @@ class SobolSampler(SALibSampler):
         self.second_order = second_order
         self._warning = False
 
-        super(SobolSampler, self).__init__()
+        super().__init__()
 
     def sample(self, problem, size):
         return saltelli.sample(problem, size, calc_second_order=self.second_order)
@@ -157,7 +157,7 @@ class MorrisSampler(SALibSampler):
     def __init__(
         self, num_levels=4, optimal_trajectories=None, local_optimization=True
     ):
-        super(MorrisSampler, self).__init__()
+        super().__init__()
         self.num_levels = num_levels
         self.optimal_trajectories = optimal_trajectories
         self.local_optimization = local_optimization
@@ -184,7 +184,7 @@ class FASTSampler(SALibSampler):
     """
 
     def __init__(self, m=4):
-        super(FASTSampler, self).__init__()
+        super().__init__()
         self.m = m
 
     def sample(self, problem, size):

--- a/ema_workbench/em_framework/samplers.py
+++ b/ema_workbench/em_framework/samplers.py
@@ -39,7 +39,7 @@ __all__ = [
 ]
 
 
-class AbstractSampler(object, metaclass=abc.ABCMeta):
+class AbstractSampler(metaclass=abc.ABCMeta):
     """
     Abstract base class from which different samplers can be derived.
 
@@ -50,7 +50,7 @@ class AbstractSampler(object, metaclass=abc.ABCMeta):
     """
 
     def __init__(self):
-        super(AbstractSampler, self).__init__()
+        super().__init__()
 
     def sample(self, distribution, size):
         """
@@ -133,7 +133,7 @@ class LHSSampler(AbstractSampler):
     """
 
     def __init__(self):
-        super(LHSSampler, self).__init__()
+        super().__init__()
 
     def sample(self, distribution, size):
         """
@@ -254,7 +254,7 @@ class MonteCarloSampler(AbstractSampler):
     """
 
     def __init__(self):
-        super(MonteCarloSampler, self).__init__()
+        super().__init__()
 
     def sample(self, distribution, size):
         """
@@ -287,7 +287,7 @@ class FullFactorialSampler(AbstractSampler):
     """
 
     def __init__(self):
-        super(FullFactorialSampler, self).__init__()
+        super().__init__()
 
     def generate_samples(self, parameters, size):
         """
@@ -632,7 +632,7 @@ def from_experiments(models, experiments):
     return scenarios
 
 
-class DefaultDesigns(object):
+class DefaultDesigns:
     """iterable for the experimental designs"""
 
     def __init__(self, designs, parameters, n):

--- a/ema_workbench/em_framework/util.py
+++ b/ema_workbench/em_framework/util.py
@@ -199,9 +199,7 @@ def combine(*args):
         overlap = set(experiment.keys()).intersection(set(entry.keys()))
         if overlap:
             raise EMAError(
-                "parameters exist in {} and {}, overlap is {}".format(
-                    experiment, entry, overlap
-                )
+                f"parameters exist in {experiment} and {entry}, overlap is {overlap}"
             )
         experiment.update(entry)
 

--- a/ema_workbench/em_framework/util.py
+++ b/ema_workbench/em_framework/util.py
@@ -64,7 +64,7 @@ class Variable(NamedObject):
 
 class NamedObjectMap:
     def __init__(self, kind):  # @ReservedAssignment
-        super(NamedObjectMap, self).__init__()
+        super().__init__()
         self.kind = kind
         self._data = OrderedDict()
 
@@ -170,7 +170,7 @@ class NamedObjectMapDescriptor:
 
 class NamedDict(UserDict, NamedObject):
     def __init__(self, name=representation, **kwargs):
-        super(NamedDict, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if name is None:
             raise ValueError()
         elif callable(name):

--- a/ema_workbench/examples/lookup_example.py
+++ b/ema_workbench/examples/lookup_example.py
@@ -25,7 +25,7 @@ class Burnout(VensimModel):
     ]
 
     def __init__(self, working_directory, name):
-        super(Burnout, self).__init__(working_directory, name)
+        super().__init__(working_directory, name)
 
         self.uncertainties = [
             LookupUncertainty(

--- a/ema_workbench/examples/models/pysd/Teacup.py
+++ b/ema_workbench/examples/models/pysd/Teacup.py
@@ -2,7 +2,6 @@
 Python model "Teacup.py"
 Translated using PySD version 0.9.0
 """
-from __future__ import division
 
 from pysd.py_backend import functions
 from pysd.py_backend.functions import cache

--- a/ema_workbench/examples/scarcity_example.py
+++ b/ema_workbench/examples/scarcity_example.py
@@ -62,7 +62,7 @@ class ScarcityModel(VensimModel):
         ]
         kwargs["approximated learning effect lookup"] = lookup
 
-        super(ScarcityModel, self).run_model(kwargs, policy)
+        super().run_model(kwargs, policy)
 
 
 if __name__ == "__main__":

--- a/ema_workbench/examples/test_examples.py
+++ b/ema_workbench/examples/test_examples.py
@@ -24,7 +24,7 @@ def redirected_output(new_stdout=None, new_stderr=None):
 
 def run_exectests(test_dir, log_path="exectests.log"):
     test_files = glob.glob(os.path.join(test_dir, "*.py"))
-    test_files = sorted([ex for ex in test_files if ex[0] != "_"])
+    test_files = sorted(ex for ex in test_files if ex[0] != "_")
     passed = []
     failed = []
     with open(log_path, "w") as f:
@@ -32,7 +32,7 @@ def run_exectests(test_dir, log_path="exectests.log"):
             for fname in test_files:
                 print(f">> Executing '{fname}'")
                 try:
-                    code = compile(set_backend + open(fname, "r").read(), fname, "exec")
+                    code = compile(set_backend + open(fname).read(), fname, "exec")
                     exec(code, {"__name__": "__main__"}, {})
                     passed.append(fname)
                 except BaseException:

--- a/ema_workbench/examples/test_examples.py
+++ b/ema_workbench/examples/test_examples.py
@@ -30,7 +30,7 @@ def run_exectests(test_dir, log_path="exectests.log"):
     with open(log_path, "w") as f:
         with redirected_output(new_stdout=f, new_stderr=f):
             for fname in test_files:
-                print(">> Executing '%s'" % fname)
+                print(f">> Executing '{fname}'")
                 try:
                     code = compile(set_backend + open(fname, "r").read(), fname, "exec")
                     exec(code, {"__name__": "__main__"}, {})
@@ -40,10 +40,10 @@ def run_exectests(test_dir, log_path="exectests.log"):
                     failed.append(fname)
                     pass
 
-    print(">> Passed %i/%i tests: " % (len(passed), len(test_files)))
+    print(f">> Passed {len(passed)}/{len(test_files)} tests: ")
     print("Passed: " + ", ".join(passed))
     print("Failed: " + ", ".join(failed))
-    print("See %s for details" % log_path)
+    print(f"See {log_path} for details")
 
     return passed, failed
 

--- a/ema_workbench/util/ema_exceptions.py
+++ b/ema_workbench/util/ema_exceptions.py
@@ -26,7 +26,7 @@ class EMAError(BaseException):
             return str(self.args)
 
     def __repr__(self):
-        return "%s(*%s)" % (self.__class__.__name__, repr(self.args))
+        return f"{self.__class__.__name__}(*{repr(self.args)})"
 
 
 class EMAWarning(EMAError):
@@ -69,7 +69,7 @@ class CaseError(EMAError):
         return self.message + " case: {" + c + "}"
 
     def __repr__(self):
-        return "%s case: %s " % (self.message, repr(self.case))
+        return f"{self.message} case: {repr(self.case)} "
 
 
 class EMAParallelError(EMAError):

--- a/ema_workbench/util/ema_logging.py
+++ b/ema_workbench/util/ema_logging.py
@@ -37,7 +37,7 @@ def create_module_logger(name=None):
         frm = inspect.stack()[1]
         mod = inspect.getmodule(frm[0])
         name = mod.__name__
-    logger = logging.getLogger("{}.{}".format(LOGGER_NAME, name))
+    logger = logging.getLogger(f"{LOGGER_NAME}.{name}")
 
     _module_loggers[name] = logger
     return logger
@@ -154,9 +154,9 @@ def method_logger(name):
         def wrapper(*args, **kwargs):
             # hack, because log is applied to methods, we can get
             # object instance as first arguments in args
-            logger.debug("calling {} on {}".format(func.__name__, classname))
+            logger.debug(f"calling {func.__name__} on {classname}")
             res = func(*args, **kwargs)
-            logger.debug("completed calling {} on {}".format(func.__name__, classname))
+            logger.debug(f"completed calling {func.__name__} on {classname}")
             return res
 
         return wrapper

--- a/ema_workbench/util/ema_logging.py
+++ b/ema_workbench/util/ema_logging.py
@@ -61,7 +61,7 @@ LOG_FORMAT = "[%(processName)s/%(levelname)s] %(message)s"
 
 class TemporaryFilter(logging.Filter):
     def __init__(self, *args, level=0, funcname=None, **kwargs):
-        super(TemporaryFilter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.level = level
         self.funcname = funcname
 

--- a/ema_workbench/util/utilities.py
+++ b/ema_workbench/util/utilities.py
@@ -49,7 +49,7 @@ def load_results(file_name):
         except KeyError:
             # old style data file
             results = load_results_old(archive)
-            _logger.info((f"results loaded successfully from {file_name}"))
+            _logger.info(f"results loaded successfully from {file_name}")
             return results
 
         metadata = json.loads(f.read().decode())
@@ -114,7 +114,7 @@ def load_results_old(archive):
         entry = entry.decode("UTF-8")
         entry = entry.strip()
         entry = entry.split(",")
-        name, dtype = [str(item) for item in entry]
+        name, dtype = (str(item) for item in entry)
 
         try:
             dtype = np.dtype(dtype)

--- a/ema_workbench/util/utilities.py
+++ b/ema_workbench/util/utilities.py
@@ -78,7 +78,7 @@ def load_results(file_name):
             values = register.deserialize(name, filename, archive)
             outcomes[name] = values
 
-    _logger.info("results loaded successfully from {}".format(file_name))
+    _logger.info(f"results loaded successfully from {file_name}")
     return experiments, outcomes
 
 
@@ -151,12 +151,12 @@ def load_results_old(archive):
 
             data = np.empty(shape)
             for i in range(nr_files):
-                values = archive.extractfile("{}_{}.csv".format(outcome, i))
+                values = archive.extractfile(f"{outcome}_{i}.csv")
                 values = pd.read_csv(values, index_col=False, header=None).values
                 data[:, :, i] = values
 
         else:
-            data = archive.extractfile("{}.csv".format(outcome))
+            data = archive.extractfile(f"{outcome}.csv")
             data = pd.read_csv(data, index_col=False, header=None).values
             data = np.reshape(data, shape)
 
@@ -278,7 +278,7 @@ def merge_results(results1, results2):
 
     # only merge the results that are in both
     keys = set(res1.keys()).intersection(set(res2.keys()))
-    _logger.info("intersection of keys: %s" % keys)
+    _logger.info(f"intersection of keys: {keys}")
 
     # merging results
     merged_res = {}
@@ -304,7 +304,7 @@ def get_ema_project_home_dir():
         parsed = config.read(fn)
 
         if parsed:
-            _logger.info("config loaded from {}".format(parsed[0]))
+            _logger.info(f"config loaded from {parsed[0]}")
         else:
             _logger.info("no config file found")
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 
 def read(path, encoding="utf-8"):
     path = os.path.join(os.path.dirname(__file__), path)
-    with io.open(path, encoding=encoding) as fp:
+    with open(path, encoding=encoding) as fp:
         return fp.read()
 
 

--- a/test/test_analysis/test_parcoords.py
+++ b/test/test_analysis/test_parcoords.py
@@ -14,7 +14,7 @@ from ema_workbench.analysis.parcoords import ParallelAxes, get_limits
 class TestParcoords(unittest.TestCase):
     def test_parallelaxis(self):
         x = pd.DataFrame(
-            [[0.1, 0, set(("a", "b"))], [1.0, 9, set(("a", "b"))]],
+            [[0.1, 0, {"a", "b"}], [1.0, 9, {"a", "b"}]],
             columns=["a", "b", "c"],
         )
 
@@ -24,7 +24,7 @@ class TestParcoords(unittest.TestCase):
 
     def test_invert_axis(self):
         x = pd.DataFrame(
-            [[0.1, 0, set(("a", "b"))], [1.0, 9, set(("a", "b"))]],
+            [[0.1, 0, {"a", "b"}], [1.0, 9, {"a", "b"}]],
             columns=["a", "b", "c"],
         )
 
@@ -133,8 +133,8 @@ class TestParcoords(unittest.TestCase):
         self.assertEqual(limits["a"][1], 1.0)
         self.assertEqual(limits["b"][0], 0)
         self.assertEqual(limits["b"][1], 9)
-        self.assertEqual(limits["c"][0], set(("a", "b")))
-        self.assertEqual(limits["c"][1], set(("a", "b")))
+        self.assertEqual(limits["c"][0], {"a", "b"})
+        self.assertEqual(limits["c"][1], {"a", "b"})
 
 
 if __name__ == "__main__":

--- a/test/test_analysis/test_prim.py
+++ b/test/test_analysis/test_prim.py
@@ -312,8 +312,8 @@ class PrimTestCase(unittest.TestCase):
         self.assertTrue(box_init["a"][1] == 1.0)
         self.assertTrue(box_init["b"][0] == 0)
         self.assertTrue(box_init["b"][1] == 9)
-        self.assertTrue(box_init["c"][0] == set(["a", "b"]))
-        self.assertTrue(box_init["c"][1] == set(["a", "b"]))
+        self.assertTrue(box_init["c"][0] == {"a", "b"})
+        self.assertTrue(box_init["c"][1] == {"a", "b"})
 
     def test_prim_exceptions(self):
         results = utilities.load_flu_data()
@@ -439,9 +439,7 @@ class PrimTestCase(unittest.TestCase):
         classify = "y"
 
         prim_obj = prim.setup_prim(results, classify, threshold=0.8)
-        box_lims = pd.DataFrame(
-            [(0, set(["a", "b"])), (1, set(["a", "b"]))], columns=["a", "b"]
-        )
+        box_lims = pd.DataFrame([(0, {"a", "b"}), (1, {"a", "b"})], columns=["a", "b"])
         box = prim.PrimBox(prim_obj, box_lims, prim_obj.yi)
 
         u = "b"
@@ -522,19 +520,15 @@ class PrimTestCase(unittest.TestCase):
             [
                 (
                     0,
-                    set(
-                        [
-                            "a",
-                        ]
-                    ),
+                    {
+                        "a",
+                    },
                 ),
                 (
                     1,
-                    set(
-                        [
-                            "a",
-                        ]
-                    ),
+                    {
+                        "a",
+                    },
                 ),
             ],
             columns=x.columns,
@@ -553,7 +547,7 @@ class PrimTestCase(unittest.TestCase):
             indices, box_lims = paste
 
             self.assertEqual(indices.shape[0], 10)
-            self.assertEqual(box_lims[u][0], set(["a", "b"]))
+            self.assertEqual(box_lims[u][0], {"a", "b"})
 
     def test_constrained_prim(self):
         experiments, outcomes = utilities.load_flu_data()

--- a/test/test_analysis/test_scenario_discovery_util.py
+++ b/test/test_analysis/test_scenario_discovery_util.py
@@ -71,7 +71,7 @@ class ScenarioDiscoveryUtilTestCase(unittest.TestCase):
             columns=["a", "b", "c"],
         )
         boxlim = pd.DataFrame(
-            [(1.2, 0, set(["a", "b"])), (8.0, 7, set(["a", "b"]))],
+            [(1.2, 0, {"a", "b"}), (8.0, 7, {"a", "b"})],
             columns=["a", "b", "c"],
         )
         x["c"] = x["c"].astype("category")
@@ -83,8 +83,8 @@ class ScenarioDiscoveryUtilTestCase(unittest.TestCase):
 
         boxlim = pd.DataFrame(
             [
-                (0.1, 0, set(["a", "b", "c", "d", "e"])),
-                (9.1, 9, set(["a", "b", "c", "d", "e"])),
+                (0.1, 0, {"a", "b", "c", "d", "e"}),
+                (9.1, 9, {"a", "b", "c", "d", "e"}),
             ],
             columns=["a", "b", "c"],
         )

--- a/test/test_connectors/test_netlogo.py
+++ b/test/test_connectors/test_netlogo.py
@@ -3,7 +3,6 @@ Created on 18 mrt. 2013
 
 .. codeauthor:: jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
 """
-from __future__ import absolute_import, print_function, division, unicode_literals
 import os
 import unittest
 from ema_workbench.connectors.netlogo import NetLogoModel

--- a/test/test_connectors/test_vensim.py
+++ b/test/test_connectors/test_vensim.py
@@ -3,7 +3,6 @@ Created on Jul 17, 2014
 
 .. codeauthor:: jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
 """
-from __future__ import absolute_import, print_function, division, unicode_literals
 import os
 import unittest
 
@@ -48,7 +47,7 @@ class LookupTestModel(VensimModel):
     def __init__(self, working_directory, name):
 
         self.model_file = r"\lookup_model.vpm"
-        super(LookupTestModel, self).__init__(working_directory, name)
+        super().__init__(working_directory, name)
 
         # vensim.load_model(self.modelFile)
         self.outcomes = [TimeSeriesOutcome("flow1")]

--- a/test/test_em_framework/test_callback.py
+++ b/test/test_em_framework/test_callback.py
@@ -87,7 +87,7 @@ class TestDefaultCallback(unittest.TestCase):
 
         _, out = callback.get_results()
 
-        self.assertIn(outcomes[0].name, set([entry for entry in out.keys()]))
+        self.assertIn(outcomes[0].name, {entry for entry in out.keys()})
         self.assertEqual(out[outcomes[0].name].shape, (3,))
 
         # case 2 time series shape = (1, nr_time_steps)

--- a/test/test_em_framework/test_ema_ipyparallel.py
+++ b/test/test_em_framework/test_ema_ipyparallel.py
@@ -59,7 +59,7 @@ class TestProcessLauncher(LocalProcessLauncher):
             self.notify_start(self.process.pid)
             self.poll = self.process.poll
         else:
-            s = "The process was already started and has state: %r" % self.state
+            s = f"The process was already started and has state: {self.state!r}"
             raise ProcessStateError(s)
 
 
@@ -79,7 +79,7 @@ def add_engines(n=1, profile="iptest", total=False):
     for i in range(n):
         ep = TestProcessLauncher()
         ep.cmd_and_args = ipengine_cmd_argv + [
-            "--profile=%s" % profile,
+            f"--profile={profile}",
             "--InteractiveShell.colors=nocolor",
         ]
         ep.start()
@@ -111,7 +111,7 @@ def setUpModule():
     tic = time.time()
     while not os.path.exists(engine_json) or not os.path.exists(client_json):
         if cp.poll() is not None:
-            raise RuntimeError("The test controller exited with status %s" % cp.poll())
+            raise RuntimeError(f"The test controller exited with status {cp.poll()}")
         elif time.time() - tic > 15:
             raise RuntimeError("Timeout waiting for the test controller to start.")
         time.sleep(0.1)
@@ -164,7 +164,7 @@ class TestEngineLoggerAdapter(unittest.TestCase):
             input_kwargs = {}
             msg, kwargs = adapter.process(input_msg, input_kwargs)
 
-            self.assertEqual("{}::{}".format(ema.SUBTOPIC, input_msg), msg)
+            self.assertEqual(f"{ema.SUBTOPIC}::{input_msg}", msg)
             self.assertEqual(input_kwargs, kwargs)
 
     @mock.patch("ema_workbench.em_framework.ema_ipyparallel.EngingeLoggerAdapter")
@@ -245,7 +245,7 @@ class TestLogWatcher(unittest.TestCase):
         ema_logging._logger = mocked_logger
 
         cls.client = ipyparallel.Client(profile="default")
-        cls.url = "tcp://{}:20202".format(localhost())
+        cls.url = f"tcp://{localhost()}:20202"
         #         cls.watcher, cls.thread = ema.start_logwatcher()
         cls.watcher = LogWatcher()
 
@@ -264,18 +264,18 @@ class TestLogWatcher(unittest.TestCase):
     def test_extract_level(self):
         level = "INFO"
         topic = ema.SUBTOPIC
-        topic_str = "engine.1.{}.{}".format(level, topic)
+        topic_str = f"engine.1.{level}.{topic}"
         extracted_level, extracted_topics = self.watcher._extract_level(topic_str)
 
         self.assertEqual(ema_logging.INFO, extracted_level)
-        self.assertEqual("engine.1.{}".format(topic), extracted_topics)
+        self.assertEqual(f"engine.1.{topic}", extracted_topics)
 
         topic = ema.SUBTOPIC
-        topic_str = "engine.1.{}".format(topic)
+        topic_str = f"engine.1.{topic}"
         extracted_level, extracted_topics = self.watcher._extract_level(topic_str)
 
         self.assertEqual(ema_logging.INFO, extracted_level)
-        self.assertEqual("engine.1.{}".format(topic), extracted_topics)
+        self.assertEqual(f"engine.1.{topic}", extracted_topics)
 
     def test_log_message(self):
         # no subscription on level
@@ -303,7 +303,7 @@ class TestLogWatcher(unittest.TestCase):
             raw = [b"engine.1.DEBUG", b"test", b"more"]
             self.watcher.log_message(raw)
             raw = [r.decode("utf-8") for r in raw]
-            mocked_logger.error.assert_called_once_with("Invalid log message: %s" % raw)
+            mocked_logger.error.assert_called_once_with(f"Invalid log message: {raw}")
 
         with mock.patch("logging.getLogger") as mocked:
             mocked_logger = mock.Mock(spec=logging.Logger)
@@ -311,7 +311,7 @@ class TestLogWatcher(unittest.TestCase):
             raw = [b"engine1DEBUG", b"test"]
             self.watcher.log_message(raw)
             raw = [r.decode("utf-8") for r in raw]
-            mocked_logger.error.assert_called_once_with("Invalid log message: %s" % raw)
+            mocked_logger.error.assert_called_once_with(f"Invalid log message: {raw}")
 
 
 class TestEngine(unittest.TestCase):

--- a/test/test_em_framework/test_ema_multiprocessing.py
+++ b/test/test_em_framework/test_ema_multiprocessing.py
@@ -2,7 +2,6 @@
 
 
 """
-from __future__ import unicode_literals, print_function, absolute_import, division
 
 
 # Created on 14 Mar 2017

--- a/test/test_em_framework/test_model.py
+++ b/test/test_em_framework/test_model.py
@@ -21,7 +21,7 @@ from ema_workbench.em_framework.outcomes import ScalarOutcome, ArrayOutcome
 
 class FileModelTest(FileModel):
     def run_model(self, scenario, policy):
-        super(FileModelTest, self).run_model(scenario, policy)
+        super().run_model(scenario, policy)
 
 
 class TestFileModel(unittest.TestCase):

--- a/test/test_em_framework/test_optimization.py
+++ b/test/test_em_framework/test_optimization.py
@@ -2,7 +2,6 @@
 
 
 """
-from __future__ import unicode_literals, print_function, absolute_import, division
 
 
 import unittest
@@ -31,7 +30,7 @@ from ema_workbench.em_framework.optimization import (
 # .. codeauthor::jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
 
 
-class MockProblem(object):
+class MockProblem:
     def __init__(self, ndv, nobjs, nconstr=0):
         pass
 
@@ -111,9 +110,9 @@ class TestOptimization(unittest.TestCase):
         self.assertListEqual(list(df.columns.values), ["a", "b", "x", "y"])
 
         for i, entry in enumerate(data):
-            self.assertListEqual(list((df.loc[i, dvnames].values)), entry.variables)
+            self.assertListEqual(list(df.loc[i, dvnames].values), entry.variables)
             self.assertListEqual(
-                list((df.loc[i, outcome_names].values)), entry.objectives
+                list(df.loc[i, outcome_names].values), entry.objectives
             )
 
     @mock.patch("ema_workbench.em_framework.optimization.platypus")

--- a/test/test_em_framework/test_samplers.py
+++ b/test/test_em_framework/test_samplers.py
@@ -31,7 +31,7 @@ class SamplerTestCase(unittest.TestCase):
     def _test_generate_designs(self, sampler):
         designs = sampler.generate_designs(self.uncertainties, 10)
         designs.kind = Scenario
-        msg = "tested for {}".format(type(sampler))
+        msg = f"tested for {type(sampler)}"
 
         actual_nr_designs = 0
         for design in designs:

--- a/test/test_em_framework/test_util.py
+++ b/test/test_em_framework/test_util.py
@@ -2,7 +2,6 @@
 
 
 """
-from __future__ import unicode_literals, print_function, absolute_import, division
 
 import unittest
 

--- a/test/test_em_framework/test_util.py
+++ b/test/test_em_framework/test_util.py
@@ -46,7 +46,7 @@ class TestNamedDict(unittest.TestCase):
 
         # test in
         for entry in kwargs.keys():
-            self.assertIn(entry, nd, "{} not in NamedDict".format(entry))
+            self.assertIn(entry, nd, f"{entry} not in NamedDict")
 
         # test addition
         nd["c"] = 3

--- a/test/test_util/test_ema_exceptions.py
+++ b/test/test_util/test_ema_exceptions.py
@@ -3,7 +3,6 @@ Created on Jul 28, 2015
 
 .. codeauthor:: jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
 """
-from __future__ import absolute_import, print_function, division, unicode_literals
 
 import unittest
 import sys
@@ -21,9 +20,9 @@ class TestEMAError(unittest.TestCase):
         error = EMAError("a message", "another message")
 
         if sys.version_info[0] < 3:
-            self.assertEqual(str(error), str("(u'a message', u'another message')"))
+            self.assertEqual(str(error), "(u'a message', u'another message')")
         else:
-            self.assertEqual(str(error), str("('a message', 'another message')"))
+            self.assertEqual(str(error), "('a message', 'another message')")
 
 
 class TestCaseError(unittest.TestCase):

--- a/test/test_util/test_utilities.py
+++ b/test/test_util/test_utilities.py
@@ -3,7 +3,6 @@ Created on 22 nov. 2012
 
 .. codeauthor:: jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
 """
-from __future__ import absolute_import, print_function, division
 import os
 import unittest
 


### PR DESCRIPTION
This PR updates the Python code with Python 3.8+, removing old, depreciated and redundant code. The biggest advantage is increased readability of the code.

This includes:
- f-string formatting of strings ([PEP 498](https://www.python.org/dev/peps/pep-0498/), Python 3.6+)
- utf-8 encoding is now the default ([PEP 3120](https://www.python.org/dev/peps/pep-3120/), Python 3.0+)
- Replace list comprehensions by Generator Expressions ([PEP 289](https://www.python.org/dev/peps/pep-0289/), Python 2.4+)
- Replace `yield` loop by `yield from` ([PEP 380](https://www.python.org/dev/peps/pep-0380/), Python 3.3+)
- Replace the IOError alias by OSError ([PEP 3151](https://www.python.org/dev/peps/pep-3151/), Python 3.3+)
- Remove the default subclass `(object)` when defining a class
- Define sets with curly braces `{}` instead of `set()`
- Remove `"r"` parameter from open function, which is default

Used [flynt](https://github.com/ikamensh/flynt) 0.76 for f-string replacement and [pyupgrade](https://github.com/asottile/pyupgrade) 2.32.0 with `--py38-plus` for all other Python features.