### PR TITLE
release CI: Build wheels for PyPI, upload artifacts to GitHub and some maintenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,22 +8,28 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Install build dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install build flake8 wheel
+          pip install --upgrade pip
+          pip install --upgrade build wheel setuptools
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Build distributions
         shell: bash -l {0}
-        run: python setup.py sdist
+        run: python setup.py sdist bdist_wheel
+
+      - name: Upload package as artifact to GitHub
+        uses: actions/upload-artifact@v3
+        with:
+          name: package
+          path: dist/
 
       - name: Publish package to PyPI
         if: github.repository == 'quaquel/EMAworkbench' && github.event_name =='push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Build distributions
         shell: bash -l {0}
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
 
       - name: Upload package as artifact to GitHub
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
A bit of modernization on the CI release workflow. Main addition is that it now builds wheels ([these things](https://realpython.com/python-wheels/#python-packaging-made-better-an-intro-to-python-wheels)) which help speed up installation on the user's side.

Another important change, in the second commit, is that it switches the build system from directly calling `setup.py` to using [build](https://github.com/pypa/build). Calling `setup.py` directly is depreciated, so this switches to using pypa's build tool for wheel and sdist building.

See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for reasoning and https://pypa-build.readthedocs.io/en/stable/ for build documentation.

To speed up testing and development, it also uploads the packaged builds to GitHub as artifact to the CI run, for easy testing before a potential release. See the `package` artifact in [this run](https://github.com/EwoutH/EMAworkbench/actions/runs/2203463316) as example.

And some other maintenance:
 - Update to actions/checkout@v3 and actions/setup-python@v3 (faster and maintained)
 - Use Python 3.10 for best performance (PyPI will respect the `python_requires` in setup.py for 3.8+ compatibility)
 - Don't install flake8, it isn't used since linting isn't done in this job