### PR TITLE
installation.rst: Add pip and conda commands, more hyperlinks

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,27 +3,30 @@ Installing the workbench
 ************************
 
 
-The 2.x version of the workbench requires Python 3.6 or higher. 
+The 2.x version of the workbench requires Python 3.8 or higher.
 
 A stable version of the workbench can be installed via pip. ::
 
 	pip install ema_workbench
 
 The code is also available from `github <https://github.com/quaquel/EMAworkbench>`_.
-The code comes with a requirements.txt file that indicates the key 
-dependencies. Basically, if you have a standard scientific computing 
-distribution for Python such as the Anaconda distribution, most of the 
-dependencies will already be met. 
+The code comes with a `requirements.txt <https://github.com/quaquel/EMAworkbench/blob/master/requirements.txt>`_ file that indicates the key
+dependencies. Basically, if you have a standard scientific computing
+distribution for Python such as the Anaconda distribution, most of the
+dependencies will already be met.
 
 
 In addition to the libraries available in the default Anaconda distribution,
 there are various optional dependencies. Please follow the installation
-instructions for each of these libraries. 
+instructions for each of these libraries.
 
-From conda or conda forge:
+From conda or `conda-forge <https://conda-forge.org/docs/user/introduction.html>`_:
 
 * `altair <https://altair-viz.github.io>`_ for interactive visualizations
-* `ipyparallel <http://ipyparallel.readthedocs.io/en/latest/>`_ for support of interactive multiprocessing within the jupyter notebook. 
+* `ipyparallel <http://ipyparallel.readthedocs.io/en/latest/>`_ for support of interactive multiprocessing within the jupyter notebook.
+::
+
+	conda install altair ipyparallel
 
 There are also some pip based dependencies:
 
@@ -32,16 +35,22 @@ There are also some pip based dependencies:
 * `platypus-opt <https://github.com/Project-Platypus/Platypus>`_ , this is an
   optional dependency for many-objective optimization functionality.
 * `pydot <https://pypi.python.org/pypi/pydot/>`_ and  Graphviz for some of the
-  visualizations. 
+  visualizations.
+::
 
-The various connectors have their own specific requirements. 
+	pip install SALib platypus-opt pydot
+
+The various connectors have their own specific requirements.
 
 * Vensim only works on Windows. If you have 64 bit vensim, you need 64 bit Python.
-  If you have 32 bit vensim, you will need 32 bit Python. 
+  If you have 32 bit vensim, you will need 32 bit Python.
 * Excel also only works on Windows.
-* `jpype-1 <https://jpype.readthedocs.io/en/latest/>`_ and 
+* `jpype-1 <https://jpype.readthedocs.io/en/latest/>`_ and
   `pynetlogo <https://pynetlogo.readthedocs.io>`_ for NetLogo
 * `pysd <https://pysd.readthedocs.io/en/master/>`_ optional for simple vensim models
 * `pythonnet <https://pypi.org/project/pythonnet/>`_ for Simio
 
-   
+::
+
+	conda install jpype1
+	pip install pynetlogo pysd pythonnet


### PR DESCRIPTION
A few small maintenance and quality-of-life changes on the installation documentation:
- Note that Python 3.8 is required (as in the Readme and setup.py)
- Add hyperlinks to the requirements.txt file and conda-forge documentation
- Add code blocks with pip and conda install commands

I was in doubt also adding things like running `conda update conda` before and specifying how to use conda-forge. On the one side, it's nice to have all the instructions to keep an environment clean and up to date in one place, on the other hand, it's not really related to the EMA workbench. What do you think?