### PR TITLE
CI: Test on Windows and macOS, Python versions, caching, maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,23 +7,31 @@ on: [push, pull_request]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.8"
+          # Python 3.10 run is disabled, because nose doesn't support Python 3.10
+          #- os: ubuntu-latest
+          #  python-version: "3.10"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 nose nose-exclude coverage coveralls
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install --upgrade pip
+        pip install flake8 nose nose-exclude coverage coveralls
+        pip install -r requirements.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -34,6 +42,7 @@ jobs:
       run:
         nosetests --exclude-dir=./test/test_connectors --with-coverage --verbose --cover-package=ema_workbench.em_framework --cover-package=ema_workbench.util --cover-package=ema_workbench.analysis
     - name: Coveralls
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: coveralls --service=github


### PR DESCRIPTION
This PR updates a few things on the CI. First of all, it extends the job matrix to run test also Windows and macOS (currently on Python 3.9) and test all Python versions supported (on Ubuntu, currently Python 3.8). If one job fails, other jobs are continued other jobs if one job fails (by setting `fail-fast: false`). It only upload test coverage on one job (currently the Ubuntu 3.9 one).

It also updates all the default actions (checkout, setup-python) to v3.

Furthermore, it speeds up the build significantly by caching the pip dependencies to speed up the job.

There are a few problems with the test package [nose](https://github.com/nose-devs/nose) however, crashing when Python 3.10 is used and not running the tests properly on Windows, executing 0 test. nose probably should be replaced by another test framework, since it's unmaintained since 2016.