### PR TITLE
cart.py: docs: Mention that cart.show_tree() needs graphviz with conda on Windows

### DIFF
--- a/ema_workbench/analysis/cart.py
+++ b/ema_workbench/analysis/cart.py
@@ -287,7 +287,9 @@ class CART(sdutil.OutputFormatterMixin):
         self.clf.fit(self._x, self.y)
 
     def show_tree(self, mplfig=True, format="png"):
-        """return a png of the tree
+        """return a png (defaults) or svg of the tree
+        
+        On Windows, graphviz needs to be installed with conda.
 
         Parameters
         ----------


### PR DESCRIPTION
On Windows, if you use show_tree() on a CART object, you need to have [graphviz](https://graphviz.org/) installed with conda (`conda install graphviz`). This commit adds a note to mention that in the docs.

See https://github.com/pydot/pydot/issues/205.