### PR TITLE
prim.py: Make PrimBox.peeling_trajectory["id"] int instead of float

### DIFF
--- a/ema_workbench/analysis/prim.py
+++ b/ema_workbench/analysis/prim.py
@@ -361,7 +361,7 @@ class PrimBox:
                    "mean": pd.Series(dtype=float),
                    "res_dim": pd.Series(dtype=int),
                    "mass": pd.Series(dtype=float),
-                   "id": pd.Series(dtype=float)}
+                   "id": pd.Series(dtype=int)}
 
         self.peeling_trajectory = pd.DataFrame(columns)
 


### PR DESCRIPTION
The `"id"` column in the `PrimBox.peeling_trajectory` DataFrame is better represented as an integer instead of a float.