### PR TITLE
analysis: Allow optional annotation of plot_tradeoff graphs

### DIFF
--- a/ema_workbench/analysis/logistic_regression.py
+++ b/ema_workbench/analysis/logistic_regression.py
@@ -254,20 +254,21 @@ class Logit:
             new_row, ignore_index=True, sort=True
         )
 
-    def show_tradeoff(self, cmap=mpl.cm.viridis):  # @UndefinedVariable
+    def show_tradeoff(self, cmap=mpl.cm.viridis, annotated=False):  # @UndefinedVariable
         """Visualize the trade off between coverage and density. Color
         is used to denote the number of restricted dimensions.
 
         Parameters
         ----------
         cmap : valid matplotlib colormap
+        annotated : bool, optional. Shows point labels if True.
 
         Returns
         -------
         a Figure instance
 
         """
-        return sdutil.plot_tradeoff(self.peeling_trajectory, cmap=cmap)
+        return sdutil.plot_tradeoff(self.peeling_trajectory, cmap=cmap, annotated=annotated)
 
     # @UndefinedVariable
     def show_threshold_tradeoff(self, i, cmap=mpl.cm.viridis_r, step=0.1):

--- a/ema_workbench/analysis/prim.py
+++ b/ema_workbench/analysis/prim.py
@@ -805,20 +805,21 @@ class PrimBox:
         """show the peeling and pasting trajectory in a figure"""
         return sdutil.plot_ppt(self.peeling_trajectory)
 
-    def show_tradeoff(self, cmap=mpl.cm.viridis):  # @UndefinedVariable
+    def show_tradeoff(self, cmap=mpl.cm.viridis, annotated=False):  # @UndefinedVariable
         """Visualize the trade off between coverage and density. Color
         is used to denote the number of restricted dimensions.
 
         Parameters
         ----------
         cmap : valid matplotlib colormap
+        annotated : bool, optional. Shows point labels if True.
 
         Returns
         -------
         a Figure instance
 
         """
-        return sdutil.plot_tradeoff(self.peeling_trajectory, cmap=cmap)
+        return sdutil.plot_tradeoff(self.peeling_trajectory, cmap=cmap, annotated=annotated)
 
     def show_pairs_scatter(self, i=None, dims=None, cdf=False):
         """Make a pair wise scatter plot of all the restricted

--- a/ema_workbench/analysis/scenario_discovery_util.py
+++ b/ema_workbench/analysis/scenario_discovery_util.py
@@ -648,13 +648,14 @@ def plot_ppt(peeling_trajectory):
     return fig
 
 
-def plot_tradeoff(peeling_trajectory, cmap=mpl.cm.viridis):  # @UndefinedVariable
+def plot_tradeoff(peeling_trajectory, cmap=mpl.cm.viridis, annotated=False):  # @UndefinedVariable
     """Visualize the trade off between coverage and density. Color
     is used to denote the number of restricted dimensions.
 
     Parameters
     ----------
     cmap : valid matplotlib colormap
+    annotated : bool, optional. Shows point labels if True.
 
     Returns
     -------
@@ -680,6 +681,10 @@ def plot_tradeoff(peeling_trajectory, cmap=mpl.cm.viridis):  # @UndefinedVariabl
     ax.set_xlabel("coverage")
     ax.set_ylim(bottom=0, top=1.2)
     ax.set_xlim(left=0, right=1.2)
+
+    if annotated:
+        for idx, row in peeling_trajectory.iterrows():
+            ax.annotate(row['id'], (row['coverage'], row['density']))
 
     ticklocs = np.arange(0, max(peeling_trajectory["res_dim"]) + 1, step=1)
     cb = fig.colorbar(p, spacing="uniform", ticks=ticklocs, drawedges=True)


### PR DESCRIPTION
Allow to annotate the points of `plot_tradeoff` graphs (which use `peeling_trajectory` DataFrames) with `id` labels. Add the optional `annotated` parameter with value `True` to do so (by default it's `False`, replicating current behaviour.

This makes it easy to quickly identify points on the tradeoff graphs which look interesting. Works best with large graphs (using [Figure.set_size_inches](https://matplotlib.org/stable/api/figure_api.html?highlight=set_size_inches#matplotlib.figure.Figure.set_size_inches)).

Example usage:
```python
from ema_workbench.analysis import prim

x = experiments
y = outcomes["max_P"] < 0.8
prim_alg = prim.Prim(x, y, threshold=0.8)
box1 = prim_alg.find_box()
box1.peeling_trajectory["id"] = box1.peeling_trajectory["id"].astype(int).astype(str)

fig = box1.show_tradeoff(annotated=True)
fig.set_size_inches((20,10))
fig.show()
```
![peeling-trajectory-annotated](https://user-images.githubusercontent.com/15776622/168099355-fa3f55ed-34d6-4396-9d49-75f2652d0325.png)