### PR TITLE
feature_scoring: fix Regressor criterion depreciation

### DIFF
--- a/ema_workbench/analysis/feature_scoring.py
+++ b/ema_workbench/analysis/feature_scoring.py
@@ -210,7 +210,7 @@ def get_rf_feature_scores(
         criterion = "gini"
     elif mode == RuleInductionType.REGRESSION:
         rfc = RandomForestRegressor
-        criterion = "mse"
+        criterion = "squared_error"
     else:
         raise ValueError(f"{mode} not valid for mode")
 
@@ -316,7 +316,7 @@ def get_ex_feature_scores(
         criterion = "gini"
     elif mode == RuleInductionType.REGRESSION:
         etc = ExtraTreesRegressor
-        criterion = "mse"
+        criterion = "squared_error"
     else:
         raise ValueError(f"{mode} not valid for mode")
 


### PR DESCRIPTION
[scikit-learn](https://scikit-learn.org/) 1.1 [depreciated](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesRegressor.html) the use of `"mse"` as regression criterion, and replaced it with `"squared_error"`. This commit fixes two of those instances in analysis/feature_scoring.py.


> Deprecated since version 1.0: Criterion “mse” was deprecated in v1.0 and will be removed in version 1.2. Use `criterion="squared_error"` which is equivalent.