### PR TITLE
feature_scoring.py: Change `max_features` in get_rf_feature_scores to `"sqrt"`

### DIFF
--- a/ema_workbench/analysis/feature_scoring.py
+++ b/ema_workbench/analysis/feature_scoring.py
@@ -161,7 +161,7 @@ def get_rf_feature_scores(
     y,
     mode=RuleInductionType.CLASSIFICATION,
     nr_trees=250,
-    max_features="auto",
+    max_features="sqrt",
     max_depth=None,
     min_samples_split=2,
     min_samples_leaf=1,


### PR DESCRIPTION
The usage of `max_features="auto"` as parameter value in [RandomForestRegressors](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html) and [ExtraTreesRegressors](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesClassifier.html#sklearn.ensemble.ExtraTreesClassifier) is depreciated in scikit-learn 1.1 and will be removed in 1.3. The default value for `max_features` also changed from from `"auto"` to `"sqrt"` in version 1.1.

This commit changes `max_features` parameter to `"sqrt"`. Behaviour should be identical. Note that this value can also be removed, since the default value is also `"sqrt"`.

Closes #127.