### PR TITLE
CI: Use Pytest instead of Nose, update default build to Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install flake8 nose nose-exclude coverage coveralls
+        pip install flake8 pytest pytest-cov coverage coveralls
         pip install -r requirements.txt
     - name: Lint with flake8
       run: |
@@ -38,9 +38,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with nose
+    - name: Test with Pytest
       run:
-        nosetests --exclude-dir=./test/test_connectors --with-coverage --verbose --cover-package=ema_workbench.em_framework --cover-package=ema_workbench.util --cover-package=ema_workbench.analysis
+        pytest --ignore=./test/test_connectors -v --cov=ema_workbench/em_framework --cov=ema_workbench/util --cov=ema_workbench/analysis
     - name: Coveralls
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
         include:
           - os: ubuntu-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
             python-version: "3.8"
-          # Python 3.10 run is disabled, because nose doesn't support Python 3.10
-          #- os: ubuntu-latest
-          #  python-version: "3.10"
 
     steps:
     - uses: actions/checkout@v3
@@ -42,7 +41,7 @@ jobs:
       run:
         pytest --ignore=./test/test_connectors -v --cov=ema_workbench/em_framework --cov=ema_workbench/util --cov=ema_workbench/analysis
     - name: Coveralls
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: coveralls --service=github


### PR DESCRIPTION
I checked with [nose2pytest](https://github.com/pytest-dev/nose2pytest) if there were any test that needed to be rewritten, and that wasn't the case. After that migrating to Pytest was quite simple, just looking up the right equivalent CLI parameters.

This PR also updates the default build (with Ubuntu, macOS and Windows) to Python 3.10, since that now works.

At some point we should probably create a workflow to test the connectors, but that's something for another time.

Closes #128.