### PR TITLE
Release CI: Only upload packages if on main repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         run: python -m build
 
       - name: Upload package as artifact to GitHub
+        if: github.repository == 'quaquel/EMAworkbench'
         uses: actions/upload-artifact@v3
         with:
           name: package


### PR DESCRIPTION
This saves GitHub some space and bandwith, which is good for the environment 🌳.