### PR TITLE
CI: Add weekly scheduled jobs and manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,12 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Build and Test
-
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,14 @@
 name: Build distribution
-
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   test:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
Add weekly jobs that run each Monday at 06:00 UTC, to test changes in the CI environment and dependencies. Also add `workflow_dispatch` to allow manually triggering the workflows ([docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on)).