### PR TITLE
evaluators.py: Allow MultiprocessingEvaluator to initialize with cpu_count minus N processes

### DIFF
--- a/ema_workbench/em_framework/evaluators.py
+++ b/ema_workbench/em_framework/evaluators.py
@@ -311,6 +311,8 @@ class MultiprocessingEvaluator(BaseEvaluator):
     ----------
     msis : collection of models
     n_processes : int (optional)
+                  A negative number can be inputted to use the number of logical cores minus the negative cores.
+                  For example, on a 12 thread processor, -2 results in using 10 threads.
     max_tasks : int (optional)
 
     """
@@ -347,6 +349,10 @@ class MultiprocessingEvaluator(BaseEvaluator):
             random_part = "".join(random_part)
             self.root_dir = os.path.abspath("tmp" + random_part)
             os.makedirs(self.root_dir)
+        
+        # Calcuate n_processes if negative value is inputted
+        if self.n_processes < 0:
+            self.n_processes = max(multiprocessing.cpu_count() + self.n_processes, 1)
 
         self._pool = multiprocessing.Pool(
             self.n_processes,


### PR DESCRIPTION
This commit allows inputting negative integers for `n_processes` in the `MultiprocessingEvaluator`. This way the number of logical CPU cores minus that negative number would be used. For example, on a 12 thread processor, `-2` results in using 10 threads. There is a guard around the function that always at least one process.

The main advantage is that when inputting a negative number, there is always some CPU power available for system and background tasks, which means the system would lag way less. When working in teams or on different devices, you can just leave it to `-1` or `-2` and always have some computing power to spare.