### PR TITLE
setup.py: Add `project_urls` for documentation and issue tracker links

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,4 +77,8 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.8",
+    project_urls={
+        'Documentation': 'https://emaworkbench.readthedocs.io/',
+        'Tracker': 'https://github.com/quaquel/EMAworkbench/issues',
+    },
 )


### PR DESCRIPTION
A small addition to `setup.py`, in which the `project_urls` property is defined with links to the documentation and issue tracker.

This allows PyPI to display direct links to the documentation and issue tracker.

![Screenshot_792](https://user-images.githubusercontent.com/15776622/172392447-664258f1-f1f4-4c1d-bbdd-8eae82fa652a.png)

See https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls