### PR TITLE
set scikit-learn requirement >= 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pyzmq
 pandas>=0.24.*
 platypus-opt
 salib
-scikit-learn
+scikit-learn>=1.0.0
 scipy
 sphinx
 seaborn


### PR DESCRIPTION
`criterion = "squared_error"`  was introduced in scikit-learn v1.0, so [feature_scoring.py](https://github.com/quaquel/EMAworkbench/blob/f718982e36689b1fb10ce50ac08de12583c3a844/ema_workbench/analysis/feature_scoring.py#L213) can run into `KeyError: 'squared_error'` when an earlier version is used. This commit updates [requirements.txt](https://github.com/quaquel/EMAworkbench/blob/master/requirements.txt) to force `scikit-learn >= 1.0.0`