### PR TITLE
optimization.py: Fix "epsilons" keyword argument in `_optimize()`

### DIFF
--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -835,7 +835,7 @@ def _optimize(
     klass = problem.types[0].__class__
 
     try:
-        eps_values = kwargs["epsilon"]
+        eps_values = kwargs["epsilons"]
     except KeyError:
         pass
     else:


### PR DESCRIPTION
The keyword argument `epsilon` isn't used anywhere else in the EMAworkbench, it should be `epsilons` (with a `s`).

So currently the `_optimize()` function (and all functions that call it) doesn't throw an error when you define a list of epsilons of the wrong length, because it searches for `epsilon` instead of `epsilons`. This PR fixes this.

Fixing this error should help catch this a lot sooner, but a bit of additional docs describing the behavior of different epsilon values, why and how certain values can be chosen and how to exactly define them should clear it up even more. I think that can be included in #147.

Maybe we can also include tests for this function, one with the right length of epsilon values and one with a wrong list length.

- [x] Fix keyword spelling
- [ ] Add tests

-----

On a bit more personal note, this behavior threw me way off, and unfortunately invalidates a lot of our results, because we thought we were defining epsilons right. We also should have provided epsilon values for all outcomes which weren't used as KPI, instead of defining only epsilon values for our KPIs.