### PR TITLE
setup.py: Define extras dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,4 +81,15 @@ setup(
         'Documentation': 'https://emaworkbench.readthedocs.io/',
         'Tracker': 'https://github.com/quaquel/EMAworkbench/issues',
     },
+    install_requires=["numpy", "pandas", "scikit-learn", "salib", "platypus-opt", "matplotlib", "statsmodels"
+                      "tqdm"]
+    extras_require={
+        "jupyter": ["jupyter", "ipython", "ipykernel"],
+        "dev": [],
+        "docs": ["sphinx", "nbsphinx", "myst", "pyscaffold"],
+        "graph": ["altair"],
+        "connectors": ["pysd"]
+        "parallel": ["ipyparallel", "traitlets"],
+        # "all": [], TODO: Create a super set that installs all above
+    }
 )


### PR DESCRIPTION
Some early work on #130. Still a work in progress.

**To-do**
- Confer about the exact allocation of dependencies in the `extras_require` dictionary
- Implement `"all"` extras which installs everything
- Update CI to use appropriate install commands for each job
- Update installation docs
- Test (using [TestPyPI](https://packaging.python.org/en/latest/guides/using-testpypi/)?)
- (optional) migrate to pyproject.toml (probably another PR)