### PR TITLE
Create release.yml file for automatic release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking changes ⚠️
+      labels:
+        - breaking
+    - title: New features added 🎉
+      labels:
+        - feature
+    - title: Enhancements made 🛠
+      labels:
+        - enhancement
+    - title: Bugs fixed 🐛
+      labels:
+        - bug
+    - title: Documentation improvements 📜
+      labels:
+        - docs
+    - title: Maintenance 🔧
+      labels:
+        - ci
+        - testing
+        - dependency
+        - maintenance
+        - packaging
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
Adds a configuration file `.github/release.yml` that lets GitHub automatically draft release notes based on the labels attached to PRs that will be included in that release. These drafted release notes can form a consistent basis for our changelog and manually expanded with context for certain PRs if needed.

The currently proposed labels are `breaking`, `feature`, `enhancement`, `bug`, `docs`, `ci`, `testing`, `dependency`, `maintenance` and `packaging`. The last four are grouped in the changelog under _Maintenance 🔧_.

See also https://github.com/quaquel/EMAworkbench/issues/138#issuecomment-1165331866 and [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).