### PR TITLE
CI: Start testing on Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         python-version: ["3.10"]
         include:
           - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-latest
             python-version: "3.9"
           - os: ubuntu-latest
             python-version: "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "salib",
     "platypus-opt",
     "matplotlib",
-    "statsmodels",
+    "statsmodels; python_version < '3.11'",
+    "statsmodels @ git+https://github.com/statsmodels/statsmodels.git ; python_version >= '3.11'",
     "seaborn",
     "tqdm",
 ]


### PR DESCRIPTION
Add a Python 3.11 job (on Ubuntu) to the testing matrix, since the first [Python 3.11 release candidate](https://www.python.org/downloads/release/python-3110rc1/) is out.