### PR TITLE
pyproject.toml: Add example/model and -/data to included package-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dynamic = ["version"] # Version is read from ema_workbench/__init__.py
 [tool.setuptools.dynamic]
 version = {attr = "ema_workbench.__version__"}
 
+[tool.setuptools.package-data]
+"ema_workbench.examples.data"
+"ema_workbench.examples.models"
+
 [project.optional-dependencies]
 jupyter = ["jupyter", "ipython", "ipykernel"]
 dev = ["pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dynamic = ["version"] # Version is read from ema_workbench/__init__.py
 version = {attr = "ema_workbench.__version__"}
 
 [tool.setuptools.package-data]
-"ema_workbench.examples.data"
-"ema_workbench.examples.models"
+"ema_workbench.examples.data" = ["*"]
+"ema_workbench.examples.models" = ["*"]
 
 [project.optional-dependencies]
 jupyter = ["jupyter", "ipython", "ipykernel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dynamic = ["version"] # Version is read from ema_workbench/__init__.py
 version = {attr = "ema_workbench.__version__"}
 
 [tool.setuptools.package-data]
-"ema_workbench.examples.data" = ["*"]
-"ema_workbench.examples.models" = ["*"]
+"ema_workbench.examples.data" = ["**"]
+"ema_workbench.examples.models" = ["**"]
 
 [project.optional-dependencies]
 jupyter = ["jupyter", "ipython", "ipykernel"]


### PR DESCRIPTION
Include all files in `ema_workbench/examples/data` and `ema_workbench/examples/models` to the data that is packaged into the wheels.

I validated that the included data is identical to the current behaviour on the master branch.

Note that this PR is merged into the pyproject branch and not into master.