### PR TITLE
Replace depreciated `shade` keyword in Seaborn kdeplot with `fill`

### DIFF
--- a/ema_workbench/analysis/logistic_regression.py
+++ b/ema_workbench/analysis/logistic_regression.py
@@ -375,7 +375,7 @@ class Logit:
         data["y"] = self.y  # for testing
         grid = sns.PairGrid(data=data, hue="y", vars=columns)
         grid.map_lower(plt.scatter, s=5)
-        grid.map_diag(sns.kdeplot, shade=True)
+        grid.map_diag(sns.kdeplot, fill=True)
         grid.add_legend()
 
         contour_levels = np.arange(0, 1.05, 0.05)


### PR DESCRIPTION
I noticed in the CI that since the seaborn v0.12 release the `shade` keyword in kdeplot is depreciated, and will be removed in seaborn v0.14. This commit replaces it with the new keyword `fill`.

```
/opt/hostedtoolcache/Python/3.10.6/x64/lib/python3.10/site-packages/seaborn/axisgrid.py:1507: FutureWarning:
`shade` is now deprecated in favor of `fill`; setting `fill=True`.
This will become an error in seaborn v0.14.0; please update your code.
```