### PR TITLE
CI: Add pip depencency caching, don't run on doc changes, update setup-python to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: 'pyproject.toml'
     - name: Install dependencies
       run: |
         pip install --upgrade pip
@@ -47,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - run: pip install flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@
 name: Build and Test
 on:
   push:
+    paths-ignore: ['docs/**', '**.rst', '**.md']
   pull_request:
+    paths-ignore: ['docs/**', '**.rst', '**.md']
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Build distribution
 on:
   push:
+    paths-ignore: ['docs/**', '**.rst', '**.md']
   pull_request:
+    paths-ignore: ['docs/**', '**.rst', '**.md']
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'


### PR DESCRIPTION
A bit of maintenance on the CI. The pip caching now works with the `pyproject.toml` file. The step to install dependencies takes about 45 seconds on Ubuntu and between 60 and 90 on macOS and Windows. If a cache is found for that branch, it can reduce the CI time by almost that amount.

Secondly, the CI now doesn't run on any changes in the `docs/` folder or changes in Markdown or reStructuredText files. This save a bit more of CI time (a.k.a. the Planet).

Also updates setup-python to v4.

Closes #163.