### PR TITLE
Fix error for negative `n_processes` input in MultiprocessingEvaluator

### DIFF
--- a/ema_workbench/em_framework/evaluators.py
+++ b/ema_workbench/em_framework/evaluators.py
@@ -351,7 +351,7 @@ class MultiprocessingEvaluator(BaseEvaluator):
                     )
                 self.n_processes = min(n_processes, max_processes)
             else:
-                self.n_processes = max(max_processes + self.n_processes, 1)
+                self.n_processes = max(max_processes + n_processes, 1)
         elif n_processes is None:
             self.n_processes = max_processes
         else:


### PR DESCRIPTION
PR #140 introduced a feature for the _MultiprocessingEvaluator_ to take a negative input for `n_processes`, which initialize the evaluator with the `cpu_count` minus that negative integer, leaving that number of cores free.

In 7dd1610 this code was refactored, introducing a bug that broke the negative-integer input functionality. When a negative integer is inputted, a `AttributeError: 'MultiprocessingEvaluator' object has no attribute 'n_processes'` was created.

The bug was caused by `self.n_processes` begin used instead of `n_processes`, where in earlier code `self.n_processes` was set equal to `n_processes` earlier in the process.

This commit fixes this behaviour by using `n_processes` to calculate `self.n_processes`.

Closes #188.

----

Unfortunately this bug landed in the EMAworkbench [2.2.0](https://github.com/quaquel/EMAworkbench/releases/tag/2.2.0) release. I would suggest creating a small bugfix release 2.2.1, in which we include the fixes for this issue (#188), the fix (#161) for the prim logging bug (#155) and the fix (b25f9bd+#183) for the 3-dimensional output saving issue (#168).