### PR TITLE
Convergence tracking

### DIFF
--- a/docs/source/indepth_tutorial/directed-search.ipynb
+++ b/docs/source/indepth_tutorial/directed-search.ipynb
@@ -685,7 +685,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/ema_workbench/em_framework/__init__.py
+++ b/ema_workbench/em_framework/__init__.py
@@ -33,14 +33,20 @@ __all__ = [
     "MultiprocessingEvaluator",
     "SequentialEvaluator",
     "ReplicatorModel",
-    "EpsilonProgress",
-    "ArchiveLogger",
     "ArrayOutcome",
     "Samplers",
     "OutputSpaceExploration",
+    "EpsilonProgress",
+    "ArchiveLogger",
     "HypervolumeMetric",
     "GenerationalDistanceMetric",
+    "SpacingMetric",
+    "InvertedGenerationalDistanceMetric",
     "EpsilonIndicatorMetric",
+    "epsilon_nondominated",
+    "rebuild_platypus_population",
+    "to_problem",
+    "to_robust_problem",
 ]
 
 from .outcomes import ScalarOutcome, TimeSeriesOutcome, Constraint, ArrayOutcome
@@ -81,6 +87,12 @@ from .optimization import (
     HypervolumeMetric,
     EpsilonIndicatorMetric,
     GenerationalDistanceMetric,
+    InvertedGenerationalDistanceMetric,
+    SpacingMetric,
+    epsilon_nondominated,
+    rebuild_platypus_population,
+    to_problem,
+    to_robust_problem,
 )
 from .outputspace_exploration import OutputSpaceExploration
 

--- a/ema_workbench/em_framework/__init__.py
+++ b/ema_workbench/em_framework/__init__.py
@@ -34,12 +34,13 @@ __all__ = [
     "SequentialEvaluator",
     "ReplicatorModel",
     "EpsilonProgress",
-    "HyperVolume",
-    "Convergence",
     "ArchiveLogger",
     "ArrayOutcome",
     "Samplers",
     "OutputSpaceExploration",
+    "HypervolumeMetric",
+    "GenerationalDistanceMetric",
+    "EpsilonIndicatorMetric",
 ]
 
 from .outcomes import ScalarOutcome, TimeSeriesOutcome, Constraint, ArrayOutcome
@@ -73,7 +74,14 @@ from .evaluators import (
     SequentialEvaluator,
     Samplers,
 )
-from .optimization import Convergence, HyperVolume, EpsilonProgress, ArchiveLogger
+from .optimization import (
+    Convergence,
+    EpsilonProgress,
+    ArchiveLogger,
+    HypervolumeMetric,
+    EpsilonIndicatorMetric,
+    GenerationalDistanceMetric,
+)
 from .outputspace_exploration import OutputSpaceExploration
 
 try:

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -845,12 +845,7 @@ class Convergence(ProgressTrackingMixIn):
                 metric(optimizer)
 
     def to_dataframe(self):
-        progress = {}
-
-        for metric in self.metrics:
-            result = metric.get_results()
-            if result:
-                progress[metric.name] = result
+        progress = {metric.name: result for metric in self.metrics if result := metric.get_results()}
 
         progress = pd.DataFrame.from_dict(progress)
 

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -845,7 +845,7 @@ class Convergence(ProgressTrackingMixIn):
                 metric(optimizer)
 
     def to_dataframe(self):
-        progress = {metric.name: result for metric in self.metrics if result := metric.get_results()}
+        progress = {metric.name: result for metric in self.metrics if (result := metric.get_results())}
 
         progress = pd.DataFrame.from_dict(progress)
 

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -530,7 +530,11 @@ class ArchiveLogger(AbstractConvergenceMetric):
         fn = os.path.join(self.directory, f"{self.base}_{self.index}_{optimizer.nfe}_nfe.csv")
 
         archive = to_dataframe(optimizer, self.decision_varnames, self.outcome_varnames)
-        archive.to_csv(fn)
+
+        # primary purpose is to avoid writing an empty dataframe to disk when convergence tracking is
+        # called the first time
+        if not archive.empty:
+            archive.to_csv(fn)
 
 
 class OperatorProbabilities(AbstractConvergenceMetric):
@@ -582,7 +586,7 @@ class Convergence(ProgressTrackingMixIn):
 
         self.generation += 1
 
-        if (nfe >= self.last_check + self.convergence_freq) or force:
+        if (nfe >= self.last_check + self.convergence_freq) or (self.last_check == 0) or force:
             self.index.append(nfe)
             self.last_check = nfe
 

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -100,7 +100,12 @@ __all__ = [
     "rebuild_platypus_population",
     "HypervolumeMetric",
     "GenerationalDistanceMetric",
+    "SpacingMetric",
+    "InvertedGenerationalDistanceMetric",
     "EpsilonIndicatorMetric",
+    "epsilon_nondominated",
+    "to_problem",
+    "to_robust_problem",
 ]
 _logger = get_module_logger(__name__)
 
@@ -718,6 +723,32 @@ class OperatorProbabilities(AbstractConvergenceMetric):
             self.results.append(props[self.index])
         except AttributeError:
             pass
+
+
+def epsilon_nondominated(results, epsilons, problem):
+    """Merge the list of results into a single set of
+    non dominated results using the provided epsilon values
+    Parameters
+    ----------
+    results : list of DataFrames
+    epsilons : epsilon values for each objective
+    problem : PlatypusProblem instance
+    Returns
+    -------
+    DataFrame
+    Notes
+    -----
+    this is a platypus based alternative to pareto.py (https://github.com/matthewjwoodruff/pareto.py)
+    """
+    if problem.nobjs != len(epsilons):
+        ValueError("the number of epsilon values must match the number of objectives")
+
+    results = pd.concat(results, ignore_index=True)
+    solutions = rebuild_platypus_population(results, problem)
+    archive = EpsilonBoxArchive(epsilons)
+    archive += solutions
+
+    return to_dataframe(archive, problem.parameter_names, problem.outcome_names)
 
 
 class Convergence(ProgressTrackingMixIn):

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -527,7 +527,7 @@ class ArchiveLogger(AbstractConvergenceMetric):
     def __call__(self, optimizer):
         self.index += 1
 
-        fn = os.path.join(self.directory, f"{self.base}_{self.index}.csv")
+        fn = os.path.join(self.directory, f"{self.base}_{self.index}_{optimizer.nfe}_nfe.csv")
 
         archive = to_dataframe(optimizer, self.decision_varnames, self.outcome_varnames)
         archive.to_csv(fn)
@@ -576,13 +576,13 @@ class Convergence(ProgressTrackingMixIn):
             assert isinstance(metric, AbstractConvergenceMetric)
             metric.reset()
 
-    def __call__(self, optimizer):
+    def __call__(self, optimizer, force=False):
         nfe = optimizer.nfe
         super().__call__(nfe - self.i)
 
         self.generation += 1
 
-        if (nfe >= self.last_check + self.convergence_freq) or self.last_check == 0:
+        if (nfe >= self.last_check + self.convergence_freq) or force:
             self.index.append(nfe)
             self.last_check = nfe
 
@@ -785,7 +785,7 @@ def _optimize(
     with temporary_filter(name=[callbacks.__name__, evaluators.__name__], level=INFO):
         optimizer.run(nfe)
 
-    convergence(optimizer)
+    convergence(optimizer, force=True)
 
     # convergence.pbar.__exit__(None, None, None)
 

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -845,7 +845,9 @@ class Convergence(ProgressTrackingMixIn):
                 metric(optimizer)
 
     def to_dataframe(self):
-        progress = {metric.name: result for metric in self.metrics if (result := metric.get_results())}
+        progress = {
+            metric.name: result for metric in self.metrics if (result := metric.get_results())
+        }
 
         progress = pd.DataFrame.from_dict(progress)
 

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -202,7 +202,6 @@ def to_robust_problem(model, scenarios, robustness_functions, constraints=None):
     robustness_functions : iterable of ScalarOutcomes
     constraints : list, optional
 
-
     Returns
     -------
     RobustProblem instance
@@ -262,6 +261,7 @@ def to_dataframe(solutions, dvnames, outcome_names):
     solutions : collection of Solution instances
     dvnames : list of str
     outcome_names : list of str
+
     Returns
     -------
     pandas DataFrame
@@ -704,10 +704,12 @@ class ArchiveLogger(AbstractConvergenceMetric):
     @classmethod
     def load_archives(cls, filename):
         """load the archives stored with the ArchiveLogger
+
         Parameters
         ----------
         filename : str
                    relative path to file
+
         Returns
         -------
         dict with nfe as key and dataframe as vlaue
@@ -757,11 +759,13 @@ class OperatorProbabilities(AbstractConvergenceMetric):
 def epsilon_nondominated(results, epsilons, problem):
     """Merge the list of results into a single set of
     non dominated results using the provided epsilon values
+
     Parameters
     ----------
     results : list of DataFrames
     epsilons : epsilon values for each objective
     problem : PlatypusProblem instance
+
     Returns
     -------
     DataFrame

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -254,23 +254,21 @@ def to_platypus_types(decision_variables):
     return types
 
 
-def to_dataframe(optimizer, dvnames, outcome_names):
-    """helper function to turn results of optimization into a pandas DataFrame
-
+def to_dataframe(solutions, dvnames, outcome_names):
+    """helper function to turn a collection of platypus Solution instances
+    into a pandas DataFrame
     Parameters
     ----------
-    optimizer : platypus algorithm instance
+    solutions : collection of Solution instances
     dvnames : list of str
     outcome_names : list of str
-
     Returns
     -------
     pandas DataFrame
-
     """
 
-    solutions = []
-    for solution in platypus.unique(optimizer.result):
+    results = []
+    for solution in platypus.unique(solutions):
         vars = transform_variables(solution.problem, solution.variables)  # @ReservedAssignment
 
         decision_vars = dict(zip(dvnames, vars))
@@ -279,9 +277,9 @@ def to_dataframe(optimizer, dvnames, outcome_names):
         result = decision_vars.copy()
         result.update(decision_out)
 
-        solutions.append(result)
+        results.append(result)
 
-    results = pd.DataFrame(solutions, columns=dvnames + outcome_names)
+    results = pd.DataFrame(results, columns=dvnames + outcome_names)
     return results
 
 
@@ -1025,7 +1023,7 @@ def _optimize(
 
     # convergence.pbar.__exit__(None, None, None)
 
-    results = to_dataframe(optimizer, problem.parameter_names, problem.outcome_names)
+    results = to_dataframe(optimizer.result, problem.parameter_names, problem.outcome_names)
     convergence = convergence.to_dataframe()
 
     message = "optimization completed, found {} solutions"

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -685,7 +685,7 @@ class ArchiveLogger(AbstractConvergenceMetric):
         self.tarfilename = os.path.join(self.directory, base_filename)
 
     def __call__(self, optimizer):
-        archive = to_dataframe(optimizer, self.decision_varnames, self.outcome_varnames)
+        archive = to_dataframe(optimizer.result, self.decision_varnames, self.outcome_varnames)
         archive.to_csv(os.path.join(self.temp, f"{optimizer.nfe}.csv"))
 
     def reset(self):

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -699,6 +699,26 @@ class ArchiveLogger(AbstractConvergenceMetric):
         shutil.rmtree(self.temp)
         return None
 
+    @classmethod
+    def load_archives(cls, filename):
+        """load the archives stored with the ArchiveLogger
+        Parameters
+        ----------
+        filename : str
+                   relative path to file
+        Returns
+        -------
+        dict with nfe as key and dataframe as vlaue
+        """
+
+        archives = {}
+        with tarfile.open(os.path.abspath(filename)) as fh:
+            for entry in fh.getmembers():
+                if entry.name.endswith("csv"):
+                    key = entry.name.split("/")[1][:-4]
+                    archives[int(key)] = pd.read_csv(fh.extractfile(entry))
+        return archives
+
 
 class OperatorProbabilities(AbstractConvergenceMetric):
     """Operator Probabiliy convergence tracker for use with

--- a/ema_workbench/em_framework/util.py
+++ b/ema_workbench/em_framework/util.py
@@ -22,6 +22,7 @@ __all__ = [
     "combine",
     "NamedObjectMapDescriptor",
     "NamedObjectMap",
+    "determine_objects",
 ]
 
 

--- a/ema_workbench/examples/lake_model_dps.py
+++ b/ema_workbench/examples/lake_model_dps.py
@@ -164,7 +164,10 @@ if __name__ == "__main__":
 
     convergence_metrics = [
         ArchiveLogger(
-            "./data", [l.name for l in lake_model.levers], [o.name for o in lake_model.outcomes]
+            "./data",
+            [l.name for l in lake_model.levers],
+            [o.name for o in lake_model.outcomes],
+            base_filename="lake_model_dps_archive.tar.gz",
         ),
         EpsilonProgress(),
     ]

--- a/ema_workbench/examples/lake_model_dps.py
+++ b/ema_workbench/examples/lake_model_dps.py
@@ -26,6 +26,8 @@ from ema_workbench import (
     Scenario,
 )
 
+from ema_workbench.em_framework.optimization import ArchiveLogger, EpsilonProgress
+
 
 # Created on 1 Jun 2017
 #
@@ -160,10 +162,18 @@ if __name__ == "__main__":
     # Watson and Kasprzyk (2017)
     reference = Scenario("reference", b=0.4, q=2, mean=0.02, stdev=0.01)
 
+    convergence_metrics = [
+        ArchiveLogger(
+            "./data", [l.name for l in lake_model.levers], [o.name for o in lake_model.outcomes]
+        ),
+        EpsilonProgress(),
+    ]
+
     with MultiprocessingEvaluator(lake_model) as evaluator:
-        evaluator.optimize(
+        results, convergence = evaluator.optimize(
             searchover="levers",
             nfe=100000,
             epsilons=[0.1] * len(lake_model.outcomes),
             reference=reference,
+            convergence=convergence_metrics,
         )


### PR DESCRIPTION
This pull request entails an overhaul of how convergence tracking is being supported by the workbench. This closes #187. 

In short:
1. ArchiveLogger now stores results in a tarbal
2. Additional helper functions for converting from a dataframe to a collection of platypus solutions 
3. Additional helper function for merging results from multiple seeds using epsilon non dominated sort
4. All platypus convergence indicators are wrapped using a wrapper class to make them play nice with the workbench.
5. HyperVolume results in a DeprecationWarning being logged. It is better to calculate hypervolume in post. This also closes #149 
6. modifications to various __init__ files to ensure the correct functions and classes can be directly imported from ema_workbench.

this pull request needs to be merged before we can resolve issue #147