### PR TITLE
Fix Matplotlib, ipyparallel and dict deprecation warnings

### DIFF
--- a/ema_workbench/analysis/b_and_w_plotting.py
+++ b/ema_workbench/analysis/b_and_w_plotting.py
@@ -24,12 +24,12 @@ __all__ = ["set_fig_to_bw"]
 _logger = get_module_logger(__name__)
 
 bw_mapping = [
-    {"marker": None, "dash": (None, None), "fill": "0.1", "hatch": "/"},
-    {"marker": None, "dash": [5, 5], "fill": "0.25", "hatch": "\\"},
-    {"marker": None, "dash": [5, 3, 1, 3], "fill": "0.4", "hatch": "|"},
-    {"marker": None, "dash": [1, 3], "fill": "0.55", "hatch": "-"},
-    {"marker": None, "dash": [5, 2, 5, 2, 5, 10], "fill": "0.7", "hatch": "o"},
-    {"marker": None, "dash": [5, 3, 1, 2, 1, 10], "fill": "0.85", "hatch": "O"},
+    {"marker": "", "dash": (None, None), "fill": "0.1", "hatch": "/"},
+    {"marker": "", "dash": [5, 5], "fill": "0.25", "hatch": "\\"},
+    {"marker": "", "dash": [5, 3, 1, 3], "fill": "0.4", "hatch": "|"},
+    {"marker": "", "dash": [1, 3], "fill": "0.55", "hatch": "-"},
+    {"marker": "", "dash": [5, 2, 5, 2, 5, 10], "fill": "0.7", "hatch": "o"},
+    {"marker": "", "dash": [5, 3, 1, 2, 1, 10], "fill": "0.85", "hatch": "O"},
     {"marker": "o", "dash": (None, None), "fill": "0.1", "hatch": "."},
 ]
 

--- a/ema_workbench/analysis/cart.py
+++ b/ema_workbench/analysis/cart.py
@@ -125,7 +125,7 @@ class CART(sdutil.OutputFormatterMixin):
         dummies = pd.get_dummies(self.x, prefix_sep=self.sep)
 
         self.dummiesmap = {}
-        for column, values in x.select_dtypes(exclude=np.number).iteritems():
+        for column, values in x.select_dtypes(exclude=np.number).items():
             mapping = {str(entry): entry for entry in values.unique()}
             self.dummiesmap[column] = mapping
 

--- a/ema_workbench/analysis/logistic_regression.py
+++ b/ema_workbench/analysis/logistic_regression.py
@@ -181,7 +181,7 @@ class Logit:
         dummies = pd.get_dummies(x, prefix_sep=self.sep)
 
         self.dummiesmap = {}
-        for column, values in self.x.select_dtypes(exclude=np.number).iteritems():
+        for column, values in self.x.select_dtypes(exclude=np.number).items():
             mapping = {str(entry): entry for entry in values.unique()}
             self.dummiesmap[column] = mapping
 

--- a/ema_workbench/analysis/parcoords.py
+++ b/ema_workbench/analysis/parcoords.py
@@ -169,7 +169,7 @@ class ParallelAxes:
         self.fontsize = fontsize
 
         # recode data
-        for column, dtype in limits.dtypes.iteritems():
+        for column, dtype in limits.dtypes.items():
             if dtype == "object":
                 cats = limits[column][0]
                 self.recoding[column] = CategoricalDtype(categories=cats, ordered=False)

--- a/ema_workbench/analysis/regional_sa.py
+++ b/ema_workbench/analysis/regional_sa.py
@@ -295,6 +295,6 @@ def plot_cdfs(x, y, ccdf=False):
 
     proxies, labels = build_legend(x, y)
 
-    fig.legend(proxies, labels, "upper center")
+    fig.legend(proxies, labels, loc="upper center")
 
     return fig

--- a/ema_workbench/analysis/scenario_discovery_util.py
+++ b/ema_workbench/analysis/scenario_discovery_util.py
@@ -226,7 +226,7 @@ def _in_box(x, boxlim):
     logical = logical.all(axis=1)
 
     # TODO:: how to speed this up
-    for column, values in x.select_dtypes(exclude=np.number).iteritems():
+    for column, values in x.select_dtypes(exclude=np.number).items():
         entries = boxlim.loc[0, column]
         not_present = set(values.cat.categories.values) - entries
 

--- a/ema_workbench/connectors/pysd_connector.py
+++ b/ema_workbench/connectors/pysd_connector.py
@@ -64,7 +64,7 @@ class BasePysdModel(AbstractModel):
         res = self.model.run(params=experiment, return_columns=self.output_variables)
 
         # EMA wants output formatted properly
-        output = {col: series.values for col, series in res.iteritems()}
+        output = {col: series.values for col, series in res.items()}
         return output
 
     def reset_model(self):

--- a/ema_workbench/connectors/vadere.py
+++ b/ema_workbench/connectors/vadere.py
@@ -215,13 +215,13 @@ class BaseVadereModel(FileModel):
             else:
                 timeseries_total = timeseries_res[next(iter(timeseries_res))]
             # format according to EMA preference
-            res = {col: series.values for col, series in timeseries_total.iteritems()}
+            res = {col: series.values for col, series in timeseries_total.items()}
 
         # handle scalar
         if scalar_res:
             for file in scalar_res:
                 s = pd.read_csv(file, sep=" ")
-                for column, data in s.iteritems():
+                for column, data in s.items():
                     res[column] = data.item()
 
         # remove temporal experiment output

--- a/test/test_em_framework/test_ema_ipyparallel.py
+++ b/test/test_em_framework/test_ema_ipyparallel.py
@@ -22,7 +22,7 @@ from IPython.paths import get_ipython_dir
 
 import ipyparallel
 from ipyparallel import Client
-from ipyparallel.apps.launcher import (
+from ipyparallel.cluster.launcher import (
     LocalProcessLauncher,
     ipengine_cmd_argv,
     ipcontroller_cmd_argv,


### PR DESCRIPTION
Maintenance in it's purest form. This PR fixed 4 types of deprecations:

- Fix `MarkerStyle(None)` deprecation in matplotlib by replacing it with `MarkerStyle('')`
- Replace deprecated `.iteritems()` with `.items()` for dicts
- Fix Matplotlib deprecation of `loc` as a positional keyword in `legend` functions 
- Import `launcher` from `ipyparallel.cluster` instead of `ipyparallel.apps`

I founds some others that might be less trivial, so I opened tracking issue (#201).

