### PR TITLE
release CI: pypa/gh-action-pypi-publish version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Publish package to PyPI
         if: github.repository == 'quaquel/EMAworkbench' && github.event_name =='push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
The master branch version has been sunset, so the release/v1 branch should now be used.

https://github.com/pypa/gh-action-pypi-publish/tree/master#-master-branch-sunset-