### PR TITLE
Replace deprecated `saltelli` with `sobol` SALib 1.4.6+.

### DIFF
--- a/ema_workbench/em_framework/salib_samplers.py
+++ b/ema_workbench/em_framework/salib_samplers.py
@@ -11,12 +11,12 @@ from .parameters import IntegerParameter
 from .samplers import DefaultDesigns
 
 try:
-    from SALib.sample import saltelli
+    from SALib.sample import sobol
     from SALib.sample import morris
     from SALib.sample import fast_sampler
 except ImportError:
     warnings.warn("SALib samplers not available", ImportWarning)
-    saltelli = morris = fast_sampler = None
+    sobol = morris = fast_sampler = None
 
 # Created on 12 Jan 2017
 #
@@ -134,7 +134,7 @@ class SobolSampler(SALibSampler):
         super().__init__()
 
     def sample(self, problem, size):
-        return saltelli.sample(problem, size, calc_second_order=self.second_order)
+        return sobol.sample(problem, size, calc_second_order=self.second_order)
 
 
 class MorrisSampler(SALibSampler):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "numpy",
     "pandas",
     "scikit-learn",
-    "salib",
+    "salib>=1.4.6",
     "platypus-opt",
     "matplotlib",
     "statsmodels",


### PR DESCRIPTION
Replace deprecated `saltelli` with `sobol` SALib 1.4.6+. Behind the scenes the Sobol method will call SciPy [`scipy.stats.qmc.Sobol`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.qmc.Sobol.html).

Fixes:
```
DeprecationWarning: salib.sample.saltelli will be removed in SALib 1.5. Please use salib.sample.sobol
```

Part of #201.