### PR TITLE
pyproject.toml: Install stable statsmodels on Python 3.11 again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ dependencies = [
     "salib>=1.4.6",
     "platypus-opt",
     "matplotlib",
-    "statsmodels; python_version < '3.11'",
-    "statsmodels @ git+https://github.com/statsmodels/statsmodels.git ; python_version >= '3.11'",
+    "statsmodels",
     "seaborn",
     "tqdm",
 ]


### PR DESCRIPTION
Statsmodels [0.13.3](https://github.com/statsmodels/statsmodels/releases/tag/v0.13.3) is released [with](https://github.com/statsmodels/statsmodels/issues/8287#issuecomment-1298905861) Python 3.11 wheels, so we don't have to install statsmodels from git anymore.

Reverts ff21348.