### PR TITLE
clusterer: Update AgglomerativeClustering keyword to fix deprecation

### DIFF
--- a/ema_workbench/analysis/clusterer.py
+++ b/ema_workbench/analysis/clusterer.py
@@ -100,7 +100,7 @@ def apply_agglomerative_clustering(distances, n_clusters, linkage="average"):
     """
 
     c = cluster.AgglomerativeClustering(
-        n_clusters=n_clusters, affinity="precomputed", linkage=linkage
+        n_clusters=n_clusters, metric="precomputed", linkage=linkage
     )
     clusters = c.fit_predict(distances)
     return clusters


### PR DESCRIPTION
Changes the keyword for the metric used to compute the linkage in [sklearn.cluster.AgglomerativeClustering](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.AgglomerativeClustering.html) from `affinity`, which is deprecated in scikit-learn 1.2, to `metric`.

Behaviour should be identical.

See https://scikit-learn.org/stable/whats_new/v1.2.html#sklearn-cluster.

> API Change The affinity attribute is now deprecated for [cluster.AgglomerativeClustering](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.AgglomerativeClustering.html#sklearn.cluster.AgglomerativeClustering) and will be renamed to metric in v1.4. [#23470](https://github.com/scikit-learn/scikit-learn/pull/23470) by [Meekail Zain](https://github.com/micky774).