### PR TITLE
CI: Timeout build job after 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
If the build job runs longer than about 12 minutes something most likely got stuck. Using 20 minutes to add some margin, but this saves a lot of compute time (since 6 hours is the default timeout) when things get stuck (and thus 🌳🌲).