### PR TITLE
Fix Matplotlib and SciPy deprecations

### DIFF
--- a/ema_workbench/analysis/b_and_w_plotting.py
+++ b/ema_workbench/analysis/b_and_w_plotting.py
@@ -260,7 +260,7 @@ def set_legend_to_bw(leg, style, colormap, line_style="continuous"):
         if isinstance(leg, list):
             leg = leg[0]
 
-        for element in leg.legendHandles:
+        for element in leg.legend_handles:
             if isinstance(element, mpl.collections.PathCollection):
                 rgb_orig = color_converter.to_rgb(element._facecolors[0])
                 new_color = color_converter.to_rgba(colormap[rgb_orig]["fill"])

--- a/ema_workbench/analysis/scenario_discovery_util.py
+++ b/ema_workbench/analysis/scenario_discovery_util.py
@@ -307,7 +307,7 @@ def _calculate_quasip(x, y, box, Hbox, Tbox):
     Tbox = int(Tbox)
 
     # force one sided
-    qp = sp.stats.binom_test(Hbox, Tbox, p, alternative="greater")  # @UndefinedVariable
+    qp = sp.stats.binomtest(Hbox, Tbox, p, alternative="greater")  # @UndefinedVariable
 
     return qp
 

--- a/ema_workbench/analysis/scenario_discovery_util.py
+++ b/ema_workbench/analysis/scenario_discovery_util.py
@@ -309,7 +309,7 @@ def _calculate_quasip(x, y, box, Hbox, Tbox):
     # force one sided
     qp = sp.stats.binomtest(Hbox, Tbox, p, alternative="greater")  # @UndefinedVariable
 
-    return qp
+    return qp.pvalue
 
 
 def plot_pair_wise_scatter(x, y, boxlim, box_init, restricted_dims, cdf=False):


### PR DESCRIPTION
Fix two deprecations:
 - Fix matplotlib deprecation in analysis/b_and_w_plotting.py
   Fix MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.
- Fix SciPy deprecation in analysis\scenario_discovery_util.py
   Fix analysis\scenario_discovery_util.py:310: DeprecationWarning: 'binom_test' is deprecated in favour of 'binomtest' from version 1.7.0 and will be removed in Scipy 1.12.0.