### PR TITLE
fixes a bug where Prim modifies the experiments array

### DIFF
--- a/ema_workbench/analysis/prim.py
+++ b/ema_workbench/analysis/prim.py
@@ -978,6 +978,8 @@ class Prim(sdutil.OutputFormatterMixin):
         assert mode in {sdutil.RuleInductionType.BINARY, sdutil.RuleInductionType.REGRESSION}
         assert self._assert_mode(y, mode, update_function)
         # preprocess x
+        x = x.copy()
+
         try:
             x.drop(columns="scenario", inplace=True)
         except KeyError:


### PR DESCRIPTION
x (the experiments) is modified inside the Prim class. This is an unintended side effect. The fix is to copy x before making any changes.