### PR TITLE
util: Speed up `combine` by ~8x 

### DIFF
--- a/ema_workbench/em_framework/util.py
+++ b/ema_workbench/em_framework/util.py
@@ -195,12 +195,13 @@ def combine(*args):
     EMAError
         if a keyword argument exists in more than one dict
     """
-    experiment = copy.deepcopy(args[0])
-    for entry in args[1::]:
-        overlap = set(experiment.keys()).intersection(set(entry.keys()))
-        if overlap:
-            raise EMAError(f"parameters exist in {experiment} and {entry}, overlap is {overlap}")
-        experiment.update(entry)
+    experiment = {}
+
+    for entry in args:
+        for key, value in entry.items():
+            if key in experiment:
+                raise EMAError(f"parameters exist in {experiment} and {entry}, overlap is {key}")
+            experiment[key] = value
 
     return experiment
 

--- a/test/test_em_framework/test_util.py
+++ b/test/test_em_framework/test_util.py
@@ -4,7 +4,7 @@
 """
 
 import unittest
-
+import copy
 from ema_workbench.em_framework import util
 
 
@@ -54,8 +54,46 @@ class TestNamedDict(unittest.TestCase):
 
 
 class TestCombine(unittest.TestCase):
-    def test_combine(self):
-        pass
+    def test_combine_two_dicts_no_overlap(self):
+        dict1 = {"a": 1, "b": 2}
+        dict2 = {"c": 3, "d": 4}
+        expected = {"a": 1, "b": 2, "c": 3, "d": 4}
+        result = util.combine(dict1, dict2)
+        self.assertEqual(result, expected)
+
+    def test_combine_multiple_dicts_no_overlap(self):
+        dict1 = {"a": 1, "b": 2}
+        dict2 = {"c": 3, "d": 4}
+        dict3 = {"e": 5, "f": 6}
+        expected = {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6}
+        result = util.combine(dict1, dict2, dict3)
+        self.assertEqual(result, expected)
+
+    def test_combine_two_dicts_with_overlap(self):
+        dict1 = {"a": 1, "b": 2}
+        dict2 = {"b": 2, "c": 3}
+        with self.assertRaises(util.EMAError):
+            util.combine(dict1, dict2)
+
+    def test_combine_multiple_dicts_with_overlap(self):
+        dict1 = {"a": 1, "b": 2}
+        dict2 = {"c": 3, "d": 4}
+        dict3 = {"a": 1, "f": 6}
+        with self.assertRaises(util.EMAError):
+            util.combine(dict1, dict2, dict3)
+
+    def test_combine_empty_dicts(self):
+        dict1 = {}
+        dict2 = {}
+        expected = {}
+        result = util.combine(dict1, dict2)
+        self.assertEqual(result, expected)
+
+    def test_combine_single_dict(self):
+        dict1 = {"a": 1, "b": 2}
+        expected = copy.deepcopy(dict1)
+        result = util.combine(dict1)
+        self.assertEqual(result, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Speed up the `combine` function by approximately 8x, by removing the intersect and deepcopy, and filling an new dictionary instead.

Benchmarks on the 25000 runs of the SIR_model:
 - old combine function: 1195ms (8.8% of runtime)
 - new combine function: 146ms (1.2% of runtime)

Note that this PR is stacked on top of #232. That one should be reviewed and merged first. For this PR only the changes in `util.py` are relevant.