### PR TITLE
Drop Python 3.8 support, require 3.9+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.9"
           - os: ubuntu-latest
-            python-version: "3.8"
-          - os: ubuntu-latest
             python-version: "3.11"
             pip-pre: "--pre"  # Installs pre-release versions of pip dependencies
             name: "Pre-release dependencies"
@@ -61,7 +59,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - run: pip install flake8
     - name: Lint with flake8
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v3.3.1
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0  # Use the ref you want to point at
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The latest release of the EMAworkbench introduces significant performance improv
 
 In addition to these performance upgrades, the examples have [been added](https://emaworkbench.readthedocs.io/en/latest/examples.html) to the ReadTheDocs documentation, more documentation improvements have been made and many bugs and deprecations have been fixed.
 
-The 2.4.x release series requires Python 3.8 and is tested on 3.8 to 3.11. It can be installed as usual via PyPI, with:
+The 2.4.x release series requires Python 3.8 and is tested on 3.8 to 3.11. It's the last release series supporting Python 3.8. It can be installed as usual via PyPI, with:
 ```
 pip install --upgrade ema-workbench
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are also a lot of example models available at [ema_workbench/examples](ema
 
 ## Installation
 
-The workbench is available from [PyPI](https://pypi.org/project/ema-workbench/), and currently requires Python 3.8 or newer. It can be installed with:
+The workbench is available from [PyPI](https://pypi.org/project/ema-workbench/), and currently requires Python 3.9 or newer. It can be installed with:
 ```
 pip install -U ema_workbench
 ```

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -2,7 +2,7 @@
 Installing the workbench
 ************************
 
-The 2.x version of the workbench requires Python 3.8 or higher.
+From version 2.5.0 the workbench requires Python 3.9 or higher. Version 2.0.0 to 2.4.x support Python 3.8+.
 
 Regular installations
 #####################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "Exploratory modelling in Python"
 readme = "README.md"
 license = { file="LICENSE.md" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers=[
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Following [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) Python 3.8 support is dropped for future minor and major releases, and will require Python 3.9+ from version 2.5.0 onwards.

The freshly released EMAworkbench 2.4.0 will support Python 3.8, as 2.4.x. patch releases.

The docs, readme, changelog, CI config and Pyupgrade are also updated.