### PR TITLE
Fix search in Readthedocs configuration with workaround

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.mathjax",
+    "sphinxcontrib.jquery",
     "nbsphinx",
     "myst_parser",
 ]


### PR DESCRIPTION
This commit fixes search by adding a workaround to the Readthedocs configuration in `conf.py`.

For the workaround see https://github.com/readthedocs/sphinx_rtd_theme/issues/1452#issuecomment-1490504991

