### PR TITLE
prim: Replace deprecated Altair function

### DIFF
--- a/ema_workbench/analysis/prim.py
+++ b/ema_workbench/analysis/prim.py
@@ -583,7 +583,7 @@ class PrimBox:
                     alt.Tooltip("res_dim:O"),
                 ],
             )
-            .properties(selection=point_selector)
+            .add_selection(point_selector)
             .properties(width=width, height=height)
         )
 

--- a/ema_workbench/analysis/prim.py
+++ b/ema_workbench/analysis/prim.py
@@ -560,7 +560,7 @@ class PrimBox:
         width = 400
         height = width
 
-        point_selector = alt.selection_single(fields=["id"])
+        point_selector = alt.selection_point(fields=["id"])
 
         peeling = self.peeling_trajectory.copy()
         peeling["id"] = peeling.index

--- a/ema_workbench/analysis/prim.py
+++ b/ema_workbench/analysis/prim.py
@@ -583,7 +583,7 @@ class PrimBox:
                     alt.Tooltip("res_dim:O"),
                 ],
             )
-            .add_selection(point_selector)
+            .add_params(point_selector)
             .properties(width=width, height=height)
         )
 


### PR DESCRIPTION
Replace [`altair.selection_single()`](https://altair-viz.github.io/user_guide/generated/api/altair.selection_single.html) with [`altair.selection_point()`](https://altair-viz.github.io/user_guide/generated/api/altair.selection_point.html), since the former is deprecated in Altair 5.0.0.

Do not merge yet, still running some tests.

Also note that Altair is not covered currently [in our CI](https://github.com/quaquel/EMAworkbench/actions/runs/4977110365/jobs/8905821870#step:5:185).