### PR TITLE
bugfix to rebuild_platypus_population

### DIFF
--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -767,6 +767,7 @@ def epsilon_nondominated(results, epsilons, problem):
     Returns
     -------
     DataFrame
+
     Notes
     -----
     this is a platypus based alternative to pareto.py (https://github.com/matthewjwoodruff/pareto.py)
@@ -878,7 +879,10 @@ def rebuild_platypus_population(archive, problem):
         objectives = [getattr(row, attr) for attr in problem.outcome_names]
 
         solution = Solution(problem)
-        solution.variables = decision_variables
+        solution.variables = [
+            platypus_type.encode(value)
+            for platypus_type, value in zip(problem.types, decision_variables)
+        ]
         solution.objectives = objectives
         solutions.append(solution)
     return solutions


### PR DESCRIPTION
The current implementation of `rebuild_platypus_population` did not properly encode the decision variables. This means that a roundtrip via to_dataframe, rebuild_platypus_population, to_dataframe does not work for non-real parameters. This fixes that by properly encoding all decision variables.

