### PR TITLE
docs/examples: Always use n_processes=-1 in MultiprocessingEvaluator

### DIFF
--- a/docs/source/examples/vadere_demo.ipynb
+++ b/docs/source/examples/vadere_demo.ipynb
@@ -211,7 +211,7 @@
    ],
    "source": [
     "# run 6 experiments in parallel\n",
-    "with MultiprocessingEvaluator(model, n_processes=4) as evaluator:\n",
+    "with MultiprocessingEvaluator(model, n_processes=-1) as evaluator:\n",
     "    experiments, outcomes = evaluator.perform_experiments(\n",
     "        scenarios=4, uncertainty_sampling=Samplers.LHS\n",
     "    )"
@@ -483,8 +483,8 @@
     }
    ],
    "source": [
-    "# run 4 experiments in parallel\n",
-    "with MultiprocessingEvaluator(model, n_processes=4) as evaluator:\n",
+    "# Run experiments in parallel with all logical CPU cores except one\n",
+    "with MultiprocessingEvaluator(model, n_processes=-1) as evaluator:\n",
     "    experiments, outcomes = evaluator.perform_experiments(\n",
     "        scenarios=4, uncertainty_sampling=Samplers.LHS\n",
     "    )"

--- a/docs/source/indepth_tutorial/open-exploration.ipynb
+++ b/docs/source/indepth_tutorial/open-exploration.ipynb
@@ -94,7 +94,7 @@
     "\n",
     "ema_logging.log_to_stderr(ema_logging.INFO)\n",
     "\n",
-    "with MultiprocessingEvaluator(model, n_processes=7) as evaluator:\n",
+    "with MultiprocessingEvaluator(model, n_processes=-1) as evaluator:\n",
     "    experiments, outcomes = evaluator.perform_experiments(scenarios=1000, policies=5)"
    ]
   },

--- a/docs/source/indepth_tutorial/open-exploration.ipynb
+++ b/docs/source/indepth_tutorial/open-exploration.ipynb
@@ -94,7 +94,9 @@
     "\n",
     "ema_logging.log_to_stderr(ema_logging.INFO)\n",
     "\n",
+    "# The n_processes=-1 ensures that all cores except 1 are used, which is kept free to keep using the computer\n",
     "with MultiprocessingEvaluator(model, n_processes=-1) as evaluator:\n",
+    "    # Run 1000 scenarios for 5 policies\n",
     "    experiments, outcomes = evaluator.perform_experiments(scenarios=1000, policies=5)"
    ]
   },

--- a/ema_workbench/examples/example_eijgenraam.py
+++ b/ema_workbench/examples/example_eijgenraam.py
@@ -219,5 +219,5 @@ if __name__ == "__main__":
 
     ema_logging.log_to_stderr(ema_logging.INFO)
 
-    with MultiprocessingEvaluator(model, n_processes=4) as evaluator:
+    with MultiprocessingEvaluator(model, n_processes=-1) as evaluator:
         results = evaluator.perform_experiments(1000, 4)

--- a/ema_workbench/examples/example_netlogo.py
+++ b/ema_workbench/examples/example_netlogo.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     # perform experiments
     n = 10
 
-    with MultiprocessingEvaluator(model, n_processes=2, maxtasksperchild=4) as evaluator:
+    with MultiprocessingEvaluator(model, n_processes=-1, maxtasksperchild=4) as evaluator:
         results = evaluator.perform_experiments(n)
 
     print()

--- a/ema_workbench/examples/example_vensim_advanced_flu.py
+++ b/ema_workbench/examples/example_vensim_advanced_flu.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
         Policy("adaptive policy", model_file="FLUvensimV1dynamic.vpm"),
     ]
 
-    with MultiprocessingEvaluator(model, n_processes=4) as evaluator:
+    with MultiprocessingEvaluator(model, n_processes=-1) as evaluator:
         results = evaluator.perform_experiments(1000, policies=policies)
 
     save_results(results, "./data/1000 flu cases with policies.tar.gz")

--- a/ema_workbench/examples/vadere_demo.ipynb
+++ b/ema_workbench/examples/vadere_demo.ipynb
@@ -211,7 +211,7 @@
    ],
    "source": [
     "# run 6 experiments in parallel\n",
-    "with MultiprocessingEvaluator(model, n_processes=4) as evaluator:\n",
+    "with MultiprocessingEvaluator(model, n_processes=-1) as evaluator:\n",
     "    experiments, outcomes = evaluator.perform_experiments(\n",
     "        scenarios=4, uncertainty_sampling=Samplers.LHS\n",
     "    )"
@@ -483,8 +483,8 @@
     }
    ],
    "source": [
-    "# run 4 experiments in parallel\n",
-    "with MultiprocessingEvaluator(model, n_processes=4) as evaluator:\n",
+    "# Run experiments in parallel with all logical CPU cores except one\n",
+    "with MultiprocessingEvaluator(model, n_processes=-1) as evaluator:\n",
     "    experiments, outcomes = evaluator.perform_experiments(\n",
     "        scenarios=4, uncertainty_sampling=Samplers.LHS\n",
     "    )"


### PR DESCRIPTION
Modify the docs and examples to always use `n_processes=-1` in MultiprocessingEvaluator. This ensure that when a user runs them, they always use most of their cores while keeping one core available for background tasks and to keep the system responsive.

The `n_processes=-1` was implemented in #140 and has been available since version [2.2.0](https://github.com/quaquel/EMAworkbench/releases/tag/2.2.0) of the EMAworkbench.