### PR TITLE
em_framework/points: Add string representation to Experiment class

### DIFF
--- a/ema_workbench/em_framework/points.py
+++ b/ema_workbench/em_framework/points.py
@@ -109,6 +109,11 @@ class Experiment(NamedObject):
         self.scenario = scenario
 
     def __repr__(self):
+        return (f"Experiment(name={self.name!r}, model_name={self.model_name!r}, "
+                f"policy={self.policy!r}, scenario={self.scenario!r}, "
+                f"experiment_id={self.experiment_id!r})")
+
+    def __str__(self):
         return f"Experiment {self.experiment_id} (model: {self.model_name}, policy: {self.policy.name}, scenario: {self.scenario.name})"
 
 

--- a/ema_workbench/em_framework/points.py
+++ b/ema_workbench/em_framework/points.py
@@ -109,9 +109,11 @@ class Experiment(NamedObject):
         self.scenario = scenario
 
     def __repr__(self):
-        return (f"Experiment(name={self.name!r}, model_name={self.model_name!r}, "
-                f"policy={self.policy!r}, scenario={self.scenario!r}, "
-                f"experiment_id={self.experiment_id!r})")
+        return (
+            f"Experiment(name={self.name!r}, model_name={self.model_name!r}, "
+            f"policy={self.policy!r}, scenario={self.scenario!r}, "
+            f"experiment_id={self.experiment_id!r})"
+        )
 
     def __str__(self):
         return f"Experiment {self.experiment_id} (model: {self.model_name}, policy: {self.policy.name}, scenario: {self.scenario.name})"

--- a/ema_workbench/em_framework/points.py
+++ b/ema_workbench/em_framework/points.py
@@ -108,6 +108,9 @@ class Experiment(NamedObject):
         self.model_name = model_name
         self.scenario = scenario
 
+    def __repr__(self):
+        return f"Experiment {self.experiment_id} (model: {self.model_name}, policy: {self.policy.name}, scenario: {self.scenario.name})"
+
 
 class ExperimentReplication(NamedDict):
     """helper class that combines scenario, policy, any constants, and


### PR DESCRIPTION
Small cherry pick from #292 to give the Experiment class in points.py a [string representation](https://docs.python.org/3/reference/datamodel.html#object.__repr__). This can be useful for keeping track of different experiments being performed while logging.