### PR TITLE
Introducing MPIEvaluator: Run on multi-node HPC systems using mpi4py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: "3.10"
+            test-mpi: true
           - os: ubuntu-latest
             python-version: "3.9"
           - os: ubuntu-latest
@@ -42,6 +43,12 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install .[dev,cov] ${{ matrix.pip-pre }}
+    - name: Install MPI and mpi4py
+      if: matrix.test-mpi == true
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libopenmpi-dev
+        pip install mpi4py
     - name: Test with Pytest
       timeout-minutes: 15
       run:

--- a/ema_workbench/__init__.py
+++ b/ema_workbench/__init__.py
@@ -15,6 +15,7 @@ from .em_framework import (
     Constant,
     Scenario,
     Policy,
+    MPIEvaluator,
     MultiprocessingEvaluator,
     IpyparallelEvaluator,
     SequentialEvaluator,

--- a/ema_workbench/em_framework/__init__.py
+++ b/ema_workbench/em_framework/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "perform_experiments",
     "optimize",
     "IpyparallelEvaluator",
+    "MPIEvaluator",
     "MultiprocessingEvaluator",
     "SequentialEvaluator",
     "ReplicatorModel",
@@ -76,6 +77,7 @@ from .salib_samplers import SobolSampler, MorrisSampler, FASTSampler, get_SALib_
 from .evaluators import (
     perform_experiments,
     optimize,
+    MPIEvaluator,
     MultiprocessingEvaluator,
     SequentialEvaluator,
     Samplers,

--- a/ema_workbench/em_framework/evaluators.py
+++ b/ema_workbench/em_framework/evaluators.py
@@ -415,6 +415,62 @@ class MultiprocessingEvaluator(BaseEvaluator):
         add_tasks(self.n_processes, self._pool, ex_gen, callback)
 
 
+# Create a global ExperimentRunner that will be used by all the worker processes
+experiment_runner = None
+
+
+def mpi_initializer(models):
+    global experiment_runner
+    experiment_runner = ExperimentRunner(models)
+
+
+class MPIEvaluator(BaseEvaluator):
+    """Evaluator for experiments using MPI Pool Executor from mpi4py"""
+
+    def __init__(self, msis, **kwargs):
+        super().__init__(msis, **kwargs)
+        self._pool = None
+
+    def initialize(self):
+        # Only import mpi4py if the MPIEvaluator is used, to avoid unnecessary dependencies.
+        from mpi4py.futures import MPIPoolExecutor
+
+        # Instead of instantiating the ExperimentRunner for each experiment, instantiate it once here
+        models = NamedObjectMap(AbstractModel)
+        models.extend(self._msis)
+
+        # Use the initializer function to set up the ExperimentRunner for all the worker processes
+        self._pool = MPIPoolExecutor(initializer=mpi_initializer, initargs=(models,))
+        _logger.info(f"MPI pool started with {self._pool._max_workers} workers")
+        return self
+
+    def finalize(self):
+        self._pool.shutdown()
+        _logger.info("MPI pool has been shut down")
+
+    def evaluate_experiments(self, scenarios, policies, callback, combine="factorial"):
+        ex_gen = experiment_generator(scenarios, self._msis, policies, combine=combine)
+        experiments = list(ex_gen)  # Convert generator to list
+
+        # Instead of sending all models for each experiment, send only the model_name
+        packed = [(experiment, experiment.model_name) for experiment in experiments]
+
+        # Use the pool to execute in parallel
+        results = self._pool.map(run_experiment_mpi, packed)
+
+        for experiment, outcomes in results:
+            callback(experiment, outcomes)
+
+
+def run_experiment_mpi(packed_data):
+    experiment, model_name = packed_data
+
+    # Use the global ExperimentRunner created by the initializer
+    outcomes = experiment_runner.run_experiment(experiment)
+
+    return experiment, outcomes
+
+
 class IpyparallelEvaluator(BaseEvaluator):
     """evaluator for using an ipypparallel pool"""
 

--- a/ema_workbench/em_framework/evaluators.py
+++ b/ema_workbench/em_framework/evaluators.py
@@ -13,6 +13,7 @@ import string
 import sys
 import threading
 import warnings
+import logging
 
 from ema_workbench.em_framework.samplers import AbstractSampler
 from .callbacks import DefaultCallback
@@ -419,9 +420,12 @@ class MultiprocessingEvaluator(BaseEvaluator):
 experiment_runner = None
 
 
-def mpi_initializer(models):
+def mpi_initializer(models, logger_level):
     global experiment_runner
     experiment_runner = ExperimentRunner(models)
+
+    # Configure logger based on the passed level and adjusted format
+    logging.basicConfig(level=logger_level, format="[%(processName)s/%(levelname)s] %(message)s")
 
 
 class MPIEvaluator(BaseEvaluator):
@@ -440,8 +444,12 @@ class MPIEvaluator(BaseEvaluator):
         models.extend(self._msis)
 
         # Use the initializer function to set up the ExperimentRunner for all the worker processes
-        self._pool = MPIPoolExecutor(initializer=mpi_initializer, initargs=(models,))
+        self._pool = MPIPoolExecutor(initializer=mpi_initializer, initargs=(models, _logger.level))
         _logger.info(f"MPI pool started with {self._pool._max_workers} workers")
+        if self._pool._max_workers <= 10:
+            _logger.warning(
+                f"With only a few workers ({self._pool._max_workers}), the MPIEvaluator may be slower than the Sequential- or MultiprocessingEvaluator"
+            )
         return self
 
     def finalize(self):
@@ -456,17 +464,29 @@ class MPIEvaluator(BaseEvaluator):
         packed = [(experiment, experiment.model_name) for experiment in experiments]
 
         # Use the pool to execute in parallel
+        _logger.info(
+            f"MPIEvaluator: Starting {len(packed)} experiments using MPI pool with {self._pool._max_workers} workers"
+        )
         results = self._pool.map(run_experiment_mpi, packed)
 
+        _logger.info(f"MPIEvaluator: Completed all {len(packed)} experiments")
         for experiment, outcomes in results:
             callback(experiment, outcomes)
+        _logger.info(f"MPIEvaluator: Callback completed for all {len(packed)} experiments")
 
 
 def run_experiment_mpi(packed_data):
+    from mpi4py.MPI import COMM_WORLD
+
+    rank = COMM_WORLD.Get_rank()
+
     experiment, model_name = packed_data
+    _logger.debug(f"MPI Rank {rank}: starting {repr(experiment)}")
 
     # Use the global ExperimentRunner created by the initializer
     outcomes = experiment_runner.run_experiment(experiment)
+
+    _logger.debug(f"MPI Rank {rank}: completed {experiment}")
 
     return experiment, outcomes
 

--- a/ema_workbench/em_framework/evaluators.py
+++ b/ema_workbench/em_framework/evaluators.py
@@ -421,6 +421,11 @@ class MPIEvaluator(BaseEvaluator):
 
     def __init__(self, msis, n_processes=None, **kwargs):
         super().__init__(msis, **kwargs)
+        warnings.warn(
+            "The MPIEvaluator is experimental. Its interface and functionality might change in future releases.\n"
+            "We welcome your feedback at: https://github.com/quaquel/EMAworkbench/discussions/311",
+            FutureWarning,
+        )
         self._pool = None
         self.n_processes = n_processes
 

--- a/ema_workbench/util/ema_logging.py
+++ b/ema_workbench/util/ema_logging.py
@@ -178,7 +178,7 @@ def get_rootlogger():
     return _rootlogger
 
 
-def log_to_stderr(level=None):
+def log_to_stderr(level=None, pass_root_logger_level=False):
     """
     Turn on logging and add a handler which prints to stderr
 
@@ -186,6 +186,10 @@ def log_to_stderr(level=None):
     ----------
     level : int
             minimum level of the messages that will be logged
+    pas_root_logger_level: bool, optional. Default False
+            if true, all module loggers will be set to the
+            same logging level as the root logger.
+            Recommended True when using the MPIEvaluator.
 
     """
 
@@ -205,5 +209,9 @@ def log_to_stderr(level=None):
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.propagate = False
+
+    if pass_root_logger_level:
+        for _, mod_logger in _module_loggers.items():
+            mod_logger.setLevel(level)
 
     return logger

--- a/test/test_em_framework/test_evaluators.py
+++ b/test/test_em_framework/test_evaluators.py
@@ -4,6 +4,7 @@
 """
 import unittest.mock as mock
 import unittest
+import platform
 
 import ema_workbench
 from ema_workbench.em_framework import evaluators
@@ -73,6 +74,51 @@ class TestEvaluators(unittest.TestCase):
         with evaluators.IpyparallelEvaluator(model, client) as evaluator:
             evaluator.evaluate_experiments(10, 10, mocked_callback)
             lb_view.map.called_once()
+
+    # Check if mpi4py is installed and if we're on a Linux environment
+    try:
+        import mpi4py
+
+        MPI_AVAILABLE = True
+    except ImportError:
+        MPI_AVAILABLE = False
+    IS_LINUX = platform.system() == "Linux"
+
+    @unittest.skipUnless(
+        MPI_AVAILABLE and IS_LINUX, "Test requires mpi4py installed and a Linux environment"
+    )
+    @mock.patch("mpi4py.futures.MPIPoolExecutor")
+    @mock.patch("ema_workbench.em_framework.evaluators.DefaultCallback")
+    @mock.patch("ema_workbench.em_framework.evaluators.experiment_generator")
+    def test_mpi_evaluator(self, mocked_generator, mocked_callback, mocked_MPIPoolExecutor):
+        try:
+            import mpi4py
+        except ImportError:
+            self.fail(
+                "mpi4py is not installed. It's required for this test. Install with: pip install mpi4py"
+            )
+
+        model = mock.Mock(spec=ema_workbench.Model)
+        model.name = "test"
+
+        # Create a mock experiment with the required attribute
+        mock_experiment = mock.Mock()
+        mock_experiment.model_name = "test"
+        mocked_generator.return_value = [mock_experiment]
+
+        pool_mock = mock.Mock()
+        pool_mock.map.return_value = [(1, ({}, {}))]
+        pool_mock._max_workers = 5  # Arbitrary number
+        mocked_MPIPoolExecutor.return_value = pool_mock
+
+        with evaluators.MPIEvaluator(model) as evaluator:
+            evaluator.evaluate_experiments(10, 10, mocked_callback)
+
+            mocked_MPIPoolExecutor.assert_called_once()
+            pool_mock.map.assert_called_once()
+
+        # Check that pool shutdown was called
+        pool_mock.shutdown.assert_called_once()
 
     def test_perform_experiments(self):
         pass


### PR DESCRIPTION
This PR adds a new experiment evaluator to the EMAworkbench, the `MPIEvaluator`. This evaluator allows experiments to be conducted on multi-node systems, including High-Performance Computers (HPC) such as [DelftBlue](https://www.tudelft.nl/dhpc/system). Internally, it uses the `MPIPoolExecutor` from [`mpi4py.futures`](mpi4py.futures).

Additionally, logging has been integrated to facilitate debugging and performance tracking in distributed setups. As a robustness measure, mocked tests have been added to ensure consistent behavior and they have been incorporated into the CI pipeline. This might help catch future breaking changes in mpi4py, such as with the upcoming 4.0 release (https://github.com/mpi4py/mpi4py/issues/386).

This PR follows from the discussions in #266 and succeeds the development PR #292.

## Conceptual design
### 1. MPIEvaluator Class

The `MPIEvaluator` class is at the main component of this design. Its primary role is to initiate a pool of workers across multiple nodes, evaluate experiments in parallel, and finalize resources when done.

**Initialization**:
- It imports `mpi4py` only when instantiated, preventing unnecessary dependencies for users who do not use the MPIEvaluator.
- The number of processes (nodes) is optionally accepted during initialization. 
- The MPI pool of workers is started, with a warning given if the number of workers is low (indicating that the evaluator might be slower than its sequential or multiprocessing counterparts).

**Evaluation**:
- Experiments are first packed with the necessary information for processing across nodes, including the model name and the experiment details.
  - Note that currently the model is included in this package. This simplifies the implementation substantially, but with larger models there might be potential for performance gains if the model isn't send with each experiment, but just once to each worker.
- Experiments are then dispatched to worker nodes for parallel processing using `MPIPoolExecutor.map()`.
- Once all experiments are done, outcomes are passed to a callback for post-processing.
  - Note: Models using a lot of memory could run out of memory before the (single) Callback. A new streaming-to-disk Callback class could help allow for models that gather data that exceeds the memory size. 

**Finalization**:
- The MPI pool of workers is shut down.

### 2. run_experiment_mpi Function

This helper function is designed to unpack experiment data, set up the necessary logging configurations, run the experiment on the designated MPI rank (node), and return the results. This is the worker function that runs on each of the MPI ranks.

**Logging**:
- Logging configurations are set up based on the level passed during experiment packing. This ensures uniformity in logging verbosity across nodes.
- Messages include MPI rank details for easier debugging.

### 3. Logging Enhancements

A dedicated logger for the `MPIEvaluator` was introduced to provide clarity during debugging and performance tracking. Several measures were taken to ensure uniform logging verbosity across nodes and improve log readability:

- The MPI process name and rank is displayed alongside the log level.
- An optional flag to adjust root logger levels was introduced, ensuring uniformity across different modules.
  - `pass_root_logger_level` argument has be added to `ema_logging.log_to_stderr`. This ensures that the root logger level is passed to all modules, so that they will log identical levels. Example:
    ```Python
    ema_logging.log_to_stderr(level=20, pass_root_logger_level=True)
    ```

## PR structure
This PR is structured in five commits:

1. **MPIEvaluator for HPC Systems (0bc9e15)**
    - **Purpose**: To extend the capabilities of the EMAworkbench to multi-node HPC systems.
    - **Changes**:
      - Introduced the `MPIEvaluator` class.
      - Added an initialization function to set up the global `ExperimentRunner` for worker processes.
      - Included proper handling for packing and unpacking experiments for efficient data transfer between nodes.
    - **Dependencies**: While the addition leverages the `mpi4py` library, it's necessary to note that the dependency on `mpi4py` is only when the `MPIEvaluator` is utilized, thus not imposing unnecessary packages on other users.

2. **Enhanced Logging for MPIEvaluator (59a2b7a)**
    - **Purpose**: To provide clear and detailed logs for debugging and performance tracking in distributed environments.
    - **Changes**:
      - Set up a dedicated logger for the `MPIEvaluator`.
      - Ensured uniform logging verbosity across nodes by passing the logger's level to each worker process.
      - Introduced log messages for tracking progress on individual MPI ranks.
      - Refined log format for better readability by displaying the MPI process name alongside the log level.

3. **Integration of MPIEvaluator Tests into CI (f51c29f)**
    - **Purpose**: To ensure the reliable functioning of the `MPIEvaluator` through continuous integration testing.
    - **Changes**:
      - Incorporated the `MPIEvaluator` into the test suite using mock tests simulating its interaction with `mpi4py`.
      - Enriched the CI pipeline (`.github/workflows/ci.yml`) to encompass MPI testing, specifically for Ubuntu with Python 3.10.
      - Included conditional logic to skip MPI tests when not on Linux platforms or in the absence of `mpi4py`.
    - **Importance**: With the upcoming `mpi4py 4.0` release, potential breaking changes can be caught early through these mocked tests.
    - **Note**: It's imperative to understand that these tests focus on the `MPIEvaluator` logic and its interactions, and do not delve into the actual internal workings of MPI.

However, a global initializer had issues with re-initializing the MPIEvaluator pool, where the second attempt would consistently throw a 'BrokenExecutor: cannot run initializer' error. This behavior was particularly evident when invoking the MPIEvaluator consecutively in a sequence.

After reproducing the issue with simplified examples and confirming its origin, the most robust approach to address this was to eliminate the common initializer function from the MPIEvaluator. This is done in dff46cd. Since the initializer also contained the logger configuration, that part was restored in f67b194. These commits are kept separate to provide insight in the development process and design considerations of the MPIEvaluator.

4. **Refinement of MPIEvaluator Initialization and Experiment Handling (dff46cd)**
    - **Purpose**: To streamline the initialization and experiment execution process within the `MPIEvaluator`.
    - **Changes**:
      - Removed the global `ExperimentRunner` and associated initializer function.
      - Adjusted the `MPIEvaluator` constructor to optionally accept the number of processes (`n_processes`).
      - Simplified the experiment packing process by including only the model name and the experiment itself.
      - Introduced an `ExperimentRunner` instantiation within the `run_experiment_mpi` function to handle experiments.

5. **Logging Configuration Enhancement (f67b194)**
    - **Purpose**: To ensure consistent logging levels across all MPI processes.
    - **Changes**:
      - Modified the experiment packing process to include the effective logging level.
      - Updated the `run_experiment_mpi` function to configure logging based on the passed level, ensuring uniformity across all worker processes.

## Technical changes per file

1. **CI Configuration (`ci.yml`)**:
    - Added an MPI testing flag to the matrix build.
    - Defined steps to set up necessary MPI libraries and the `mpi4py` package.

2. **EMAworkbench Initialization Files**:
    - Imported and initialized the `MPIEvaluator`.

3. **Evaluator Logic Enhancements (`evaluators.py`)**:
    - Defined global `ExperimentRunner` for worker processes.
    - Added the `MPIEvaluator` class with its initialization, finalization, and experiment evaluation logic.
    - Implemented logic to handle experiments in an MPI environment.

4. **Logging Improvements (`ema_logging.py`)**:
    - Introduced an optional flag to adjust log levels for the root logger.

5. **Test Enhancements (`test_evaluators.py`)**:
    - Incorporated mocked tests for the `MPIEvaluator`, conditional on the availability of `mpi4py` and a Linux environment.

## Logging
Logging is a big part of this PR. Being able to debug failures and errors on HPC systems effectively is important, because the iteration speed is on these systems if often low (since you have to queue jobs).

This is how the current logs work for a simple model example run:

INFO level (20)
```
[MainProcess/INFO] MPI pool started with 9 workers
[MainProcess/WARNING] With only a few workers (9), the MPIEvaluator may be slower than the Sequential- or MultiprocessingEvaluator
[MainProcess/INFO] performing 25 scenarios * 1 policies * 1 model(s) = 25 experiments
  0%|                                                   | 0/25 [00:00<?, ?it/s][MainProcess/INFO] MPIEvaluator: Starting 25 experiments using MPI pool with 9 workers
[MainProcess/INFO] MPIEvaluator: Completed all 25 experiments
100%|██████████████████████████████████████████| 25/25 [00:00<00:00, 39.04it/s]
[MainProcess/INFO] MPIEvaluator: Callback completed for all 25 experiments
[MainProcess/INFO] experiments finished
[MainProcess/INFO] MPI pool has been shut down
```

<details><summary>DEBUG level</summary>

```
[MainProcess/INFO] MPI pool started with 9 workers
[MainProcess/WARNING] With only a few workers (9), the MPIEvaluator may be slower than the Sequential- or MultiprocessingEvaluator
[MainProcess/INFO] performing 25 scenarios * 1 policies * 1 model(s) = 25 experiments
  0%|                                                   | 0/25 [00:00<?, ?it/s][MainProcess/INFO] MPIEvaluator: Starting 25 experiments using MPI pool with 9 workers
[MainProcess/INFO] MPIEvaluator: Completed all 25 experiments
[MainProcess/DEBUG] MPI Rank 1: starting Experiment(name='simpleModel None 0', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 2.0829145226976835, 'x2': -0.007878333224039757, 'x3': -0.0009740476752629831}), experiment_id=0)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 2: starting Experiment(name='simpleModel None 1', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 0.6097172301360301, 'x2': -0.007528201393234191, 'x3': 0.007709262322100828}), experiment_id=1)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 0 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] running scenario 1 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] MPI Rank 5: starting Experiment(name='simpleModel None 4', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 6.266259219423759, 'x2': -0.00337617120143388, 'x3': -0.008074954689949926}), experiment_id=4)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 7: starting Experiment(name='simpleModel None 6', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 1.6937743192292463, 'x2': -0.004134864569602595, 'x3': 0.0011194805732659095}), experiment_id=6)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 4 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] running scenario 6 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] MPI Rank 6: starting Experiment(name='simpleModel None 5', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 4.304935288926784, 'x2': 0.00061753325715346, 'x3': -0.0030157106915799856}), experiment_id=5)
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] running scenario 5 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] MPI Rank 9: starting Experiment(name='simpleModel None 8', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 9.958653269070073, 'x2': -0.002413434028158994, 'x3': 0.0023440265846300205}), experiment_id=8)
[MainProcess/DEBUG] MPI Rank 4: starting Experiment(name='simpleModel None 3', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 1.1378714219956574, 'x2': 0.006880507077623674, 'x3': 0.005504065805926132}), experiment_id=3)
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] MPI Rank 8: starting Experiment(name='simpleModel None 7', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 0.1727896233646382, 'x2': -0.000982020382601088, 'x3': 0.003327952320623955}), experiment_id=7)
[MainProcess/DEBUG] MPI Rank 3: starting Experiment(name='simpleModel None 2', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 8.7962163908074, 'x2': -0.009981449292094727, 'x3': -0.0038280997193846098}), experiment_id=2)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] running scenario 3 for policy None on model simpleModel
[MainProcess/DEBUG] running scenario 8 for policy None on model simpleModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 7 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] running scenario 2 for policy None on model simpleModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 1: completed Experiment 0 (model: simpleModel, policy: None, scenario: 0)
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 2: completed Experiment 1 (model: simpleModel, policy: None, scenario: 1)
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 6: completed Experiment 5 (model: simpleModel, policy: None, scenario: 5)
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 7: completed Experiment 6 (model: simpleModel, policy: None, scenario: 6)
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 5: completed Experiment 4 (model: simpleModel, policy: None, scenario: 4)
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 8: completed Experiment 7 (model: simpleModel, policy: None, scenario: 7)
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 3: completed Experiment 2 (model: simpleModel, policy: None, scenario: 2)
[MainProcess/DEBUG] MPI Rank 6: starting Experiment(name='simpleModel None 12', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 1.635146092974492, 'x2': -0.0062798465407033904, 'x3': -0.008594200709001644}), experiment_id=12)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 12 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 9: completed Experiment 8 (model: simpleModel, policy: None, scenario: 8)
[MainProcess/DEBUG] MPI Rank 1: starting Experiment(name='simpleModel None 9', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 3.9784232294826705, 'x2': 0.008577070681243982, 'x3': 0.00015405200963791027}), experiment_id=9)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 9 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 4: completed Experiment 3 (model: simpleModel, policy: None, scenario: 3)
[MainProcess/DEBUG] MPI Rank 4: starting Experiment(name='simpleModel None 11', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 3.192582283926509, 'x2': 0.0048337454591713055, 'x3': 0.0039418271321421654}), experiment_id=11)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 11 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] MPI Rank 5: starting Experiment(name='simpleModel None 16', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 7.936943878171319, 'x2': 0.004366194761901594, 'x3': 0.001489162880869744}), experiment_id=16)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 16 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] MPI Rank 3: starting Experiment(name='simpleModel None 14', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 9.321454486239302, 'x2': 0.001562762240739304, 'x3': 0.008992833791031921}), experiment_id=14)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 14 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] MPI Rank 2: starting Experiment(name='simpleModel None 10', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 3.5394552051248, 'x2': 0.006780661665895806, 'x3': -0.006355045440043552}), experiment_id=10)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 10 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
  4%|█▋                                         | 1/25 [00:00<00:05,  4.30it/s][MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] MPI Rank 7: starting Experiment(name='simpleModel None 15', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 6.505963595145575, 'x2': 0.009669568131733563, 'x3': 0.009852481211068803}), experiment_id=15)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 15 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] MPI Rank 8: starting Experiment(name='simpleModel None 13', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 8.15536364639159, 'x2': 0.0020707297931449892, 'x3': 0.0067288601313206745}), experiment_id=13)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 13 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] MPI Rank 9: starting Experiment(name='simpleModel None 17', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 4.878475541405726, 'x2': 0.007665523368552666, 'x3': 0.007371176206485841}), experiment_id=17)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 17 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 1: completed Experiment 9 (model: simpleModel, policy: None, scenario: 9)
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 4: completed Experiment 11 (model: simpleModel, policy: None, scenario: 11)
[MainProcess/DEBUG] MPI Rank 4: starting Experiment(name='simpleModel None 19', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 9.17134521547357, 'x2': -0.008524107715765134, 'x3': -0.005158661354858541}), experiment_id=19)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 1: starting Experiment(name='simpleModel None 18', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 5.416240399907894, 'x2': -0.0012159298484620846, 'x3': -0.009228811770848973}), experiment_id=18)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 18 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 5: completed Experiment 16 (model: simpleModel, policy: None, scenario: 16)
 40%|████████████████▊                         | 10/25 [00:00<00:00, 27.30it/s][MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 19 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] MPI Rank 6: completed Experiment 12 (model: simpleModel, policy: None, scenario: 12)
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 8: completed Experiment 13 (model: simpleModel, policy: None, scenario: 13)
[MainProcess/DEBUG] MPI Rank 7: completed Experiment 15 (model: simpleModel, policy: None, scenario: 15)
[MainProcess/DEBUG] MPI Rank 7: starting Experiment(name='simpleModel None 23', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 2.552098964515078, 'x2': 0.00024019172488336585, 'x3': -0.0020777525992340135}), experiment_id=23)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 23 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] MPI Rank 6: starting Experiment(name='simpleModel None 21', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 5.791919188785238, 'x2': -0.0056467729260636845, 'x3': -0.007365480953875257}), experiment_id=21)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 21 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] MPI Rank 5: starting Experiment(name='simpleModel None 20', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 7.119138469408275, 'x2': 0.0033181138303110536, 'x3': 0.004893059686998311}), experiment_id=20)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 20 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 3: completed Experiment 14 (model: simpleModel, policy: None, scenario: 14)
[MainProcess/DEBUG] MPI Rank 8: starting Experiment(name='simpleModel None 22', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 4.698277666358151, 'x2': 0.005579333312602821, 'x3': -0.0017796670394285476}), experiment_id=22)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 2: completed Experiment 10 (model: simpleModel, policy: None, scenario: 10)
[MainProcess/DEBUG] running scenario 22 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] MPI Rank 3: starting Experiment(name='simpleModel None 24', model_name='simpleModel', policy=Policy({}), scenario=Policy({'x1': 7.364100121292793, 'x2': -0.00503473305035102, 'x3': -0.0059506479282402}), experiment_id=24)
[MainProcess/DEBUG] calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] running scenario 24 for policy None on model simpleModel
[MainProcess/DEBUG] calling run_model on SingleReplication
[MainProcess/DEBUG] calling run_model on AbstractModel
[MainProcess/DEBUG] calling initialized on AbstractModel
[MainProcess/DEBUG] completed calling initialized on AbstractModel
[MainProcess/DEBUG] calling model_init on AbstractModel
[MainProcess/DEBUG] completed calling model_init on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling _transform on AbstractModel
[MainProcess/DEBUG] completed calling run_model on AbstractModel
[MainProcess/DEBUG] calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 9: completed Experiment 17 (model: simpleModel, policy: None, scenario: 17)
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 1: completed Experiment 18 (model: simpleModel, policy: None, scenario: 18)
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 4: completed Experiment 19 (model: simpleModel, policy: None, scenario: 19)
 76%|███████████████████████████████▉          | 19/25 [00:00<00:00, 34.68it/s][MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] MPI Rank 6: completed Experiment 21 (model: simpleModel, policy: None, scenario: 21)
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 5: completed Experiment 20 (model: simpleModel, policy: None, scenario: 20)
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 7: completed Experiment 23 (model: simpleModel, policy: None, scenario: 23)
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 8: completed Experiment 22 (model: simpleModel, policy: None, scenario: 22)
[MainProcess/DEBUG] completed calling run_experiment on BaseModel
[MainProcess/DEBUG] completed calling run_model on SingleReplication
[MainProcess/DEBUG] calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling reset_model on AbstractModel
[MainProcess/DEBUG] completed calling run_experiment on ExperimentRunner
[MainProcess/DEBUG] MPI Rank 3: completed Experiment 24 (model: simpleModel, policy: None, scenario: 24)
100%|██████████████████████████████████████████| 25/25 [00:00<00:00, 38.94it/s]
[MainProcess/INFO] MPIEvaluator: Callback completed for all 25 experiments
[MainProcess/INFO] experiments finished
[MainProcess/INFO] MPI pool has been shut down
```
</details>

## Performance

### Overhead
![boxplot](https://github.com/quaquel/EMAworkbench/assets/15776622/297f1179-7895-4965-ae66-e22b6b9df4ec)

Divided by 10 cores:

| Model   |   SequentialEvaluator |   MultiprocessingEvaluator |   MPIEvaluator |
|:--------|----------------------:|---------------------------:|---------------:|
| python  |                     1 |                     0.0135 |         0.0101 |
| lake    |                     1 |                     0.4296 |         0.3037 |
| flu     |                     1 |                     0.4041 |         0.3976 |

Undivided:

| Model   |   SequentialEvaluator |   MultiprocessingEvaluator |   MPIEvaluator |
|:--------|----------------------:|---------------------------:|---------------:|
| python  |                     1 |                      0.135 |          0.101 |
| lake    |                     1 |                      4.296 |          3.037 |
| flu     |                     1 |                      4.041 |          3.976 |

### Scaling
The first one used shared nodes, which shows inconsistent performance:

![boxplot_lake](https://github.com/quaquel/EMAworkbench/assets/15776622/a44ddecc-562f-4f95-b5e8-5c9af204a1ce)

The second two experiments claimed full nodes exclusively. While normally this isn't best practice, it was useful to get insight in performance scaling.
![boxplot_lake_exclusive](https://github.com/quaquel/EMAworkbench/assets/15776622/8606f9c7-aa68-407b-ae07-30210ddae6d3)
![boxplot_flu](https://github.com/quaquel/EMAworkbench/assets/15776622/babf86bb-4375-4ff4-a5f2-2b3ed308eb54)

Both models are relatively simple with large communication overhead. Testing the performance on a more compute intensive model would be interesting for future research. The [MPIEvaluator-benchmarks](https://github.com/quaquel/EMAworkbench/tree/MPIEvaluator-benchmarks) branch can be used for this.

## Documentation
A tutorial for the MPIEvaluator will be added in PR #308.

## Limitations & future enhancements
There are two main limitations currently:
- The MPIEvaluator is not tested with file-based models, such as NetLogo and Vensim. It might still work, but it's not tested. Originally this was in scope for this PR, but due to difficulties in creating the proper environment, this was cut out of the scope of this efford.
- The model object is currently passed to the worker for each experiment. For large models with a relatively short runtime, this introduces significant performance overhead. Therefore, and optimization could be made to send the model only once to a worker on initialization.
  - Building on this, submitting experiment parameter sets in batches could also help increate performance, instead of sending them to the workers one-by-one.

Some other future improvements could be:
- A new Callback class could be implemented that streams to the disk instead of keeping all results in memory. This would allow for handling very large model that gather lots of data, probably at the costs of some performance. See issue #304 for more details.
- Further performance profiling could be done on the current design, to see any components can be sped up, like the distribution of experiments and models to workers, the logging or the.
  - It would be interesting to see how larger models perform on many-node systems, and if the scaling is better than with the small _lake_ and _flu_ models. 

## Review
This PR is ready for review.

When merging, the preferred method would be [fast-forward merge](https://github.com/quaquel/EMAworkbench/blob/master/CONTRIBUTING.md#merging-pull-requests) to keep individual commit messages and be able to revert one if necessary.