### PR TITLE
examples: Speedup the lake_problem function by ~30x

### DIFF
--- a/ema_workbench/examples/example_lake_model.py
+++ b/ema_workbench/examples/example_lake_model.py
@@ -35,37 +35,47 @@ def lake_problem(
         decisions = [kwargs[str(i)] for i in range(100)]
     except KeyError:
         decisions = [0] * 100
+        print("No valid decisions found, using 0 water release every year as default")
 
-    Pcrit = brentq(lambda x: x**q / (1 + x**q) - b * x, 0.01, 1.5)
     nvars = len(decisions)
-    X = np.zeros((nvars,))
-    average_daily_P = np.zeros((nvars,))
     decisions = np.array(decisions)
-    reliability = 0.0
 
-    for _ in range(nsamples):
-        X[0] = 0.0
+    # Calculate the critical pollution level (Pcrit)
+    Pcrit = brentq(lambda x: x**q / (1 + x**q) - b * x, 0.01, 1.5)
 
-        natural_inflows = np.random.lognormal(
-            math.log(mean**2 / math.sqrt(stdev**2 + mean**2)),
-            math.sqrt(math.log(1.0 + stdev**2 / mean**2)),
-            size=nvars,
+    # Generate natural inflows using lognormal distribution
+    natural_inflows = np.random.lognormal(
+        mean=math.log(mean**2 / math.sqrt(stdev**2 + mean**2)),
+        sigma=math.sqrt(math.log(1.0 + stdev**2 / mean**2)),
+        size=(nsamples, nvars),
+    )
+
+    # Initialize the pollution level matrix X
+    X = np.zeros((nsamples, nvars))
+
+    # Loop through time to compute the pollution levels
+    for t in range(1, nvars):
+        X[:, t] = (
+            (1 - b) * X[:, t - 1]
+            + (X[:, t - 1] ** q / (1 + X[:, t - 1] ** q))
+            + decisions[t - 1]
+            + natural_inflows[:, t - 1]
         )
 
-        for t in range(1, nvars):
-            X[t] = (
-                (1 - b) * X[t - 1]
-                + X[t - 1] ** q / (1 + X[t - 1] ** q)
-                + decisions[t - 1]
-                + natural_inflows[t - 1]
-            )
-            average_daily_P[t] += X[t] / float(nsamples)
+    # Calculate the average daily pollution for each time step
+    average_daily_P = np.mean(X, axis=0)
 
-        reliability += np.sum(X < Pcrit) / float(nsamples * nvars)
+    # Calculate the reliability (probability of the pollution level being below Pcrit)
+    reliability = np.sum(X < Pcrit) / float(nsamples * nvars)
 
+    # Calculate the maximum pollution level (max_P)
     max_P = np.max(average_daily_P)
+
+    # Calculate the utility by discounting the decisions using the discount factor (delta)
     utility = np.sum(alpha * decisions * np.power(delta, np.arange(nvars)))
-    inertia = np.sum(np.absolute(np.diff(decisions)) < 0.02) / float(nvars - 1)
+
+    # Calculate the inertia (the fraction of time steps with changes larger than 0.02)
+    inertia = np.sum(np.abs(np.diff(decisions)) > 0.02) / float(nvars - 1)
 
     return max_P, utility, inertia, reliability
 


### PR DESCRIPTION
Speedup the `lake_problem` function in the `example_lake_model.py` example.

This is an one-on-one adaptation of https://github.com/quaquel/epa1361/pull/4.

> Speed up the `lake_problem` function by around 30x, by flattening a loop and computing those values in NumPy arrays.
> 
> ![performance_boxplot](https://user-images.githubusercontent.com/15776622/226147970-eed85329-9de3-45d5-af3c-d45ec65c10ed.svg) _Average duration of 100 lake_model experiments: 0.940 seconds vs 0.030 seconds (speed up: 31.41)._
> 
> I validated the output and it is consistent with the previous function:
> 
> ```python
> def validate_new_function():
>     result_original = lake_problem()
>     result_optimized = lake_problem_fast()
> 
>     # Check if the results are the same within a given tolerance
>     assert np.allclose(result_original, result_optimized, rtol=1e-3, atol=1e-3), "Outputs are not the same: {} vs. {}".format(result_original, result_optimized)
> 
> for _ in range(10):
>     try:
>         validate_new_function()
>     except AssertionError as e:
>         print(e)
> ```
> 
> It prints nothing, which means all outputs are withing 0.1% of each other (due to the stochastic nature of the `random.lognormal()` draw it's never exactly the same).
> 
> The full analysis can be viewed in [this notebook](https://github.com/quaquel/epa1361/blob/cd4c5b288803b583a4fa4c90b82e428c83c70b48/Week%201-2%20-%20general%20intro%20to%20exploratory%20modelling/performance_analysis.ipynb).
> 
> This over an order of magnitude speedup will help students iterate faster when learning and playing with the exercises, and might enable some new assignments and examples previously out of scope due to performance limitations.

Also add a warning on the decisions KeyError.