### PR TITLE
CI: Switch default jobs to Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
         name: [""]
         include:
           - os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
             test-mpi: true
+          - os: ubuntu-latest
+            python-version: "3.10"
           - os: ubuntu-latest
             python-version: "3.9"
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             pip-pre: "--pre"  # Installs pre-release versions of pip dependencies
             name: "Pre-release dependencies"
 
@@ -66,7 +68,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - run: pip install flake8
     - name: Lint with flake8
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install build dependencies
         run: |

--- a/test/test_em_framework/test_evaluators.py
+++ b/test/test_em_framework/test_evaluators.py
@@ -73,7 +73,7 @@ class TestEvaluators(unittest.TestCase):
 
         with evaluators.IpyparallelEvaluator(model, client) as evaluator:
             evaluator.evaluate_experiments(10, 10, mocked_callback)
-            lb_view.map.called_once()
+            lb_view.map.assert_called_once()
 
     # Check if mpi4py is installed and if we're on a Linux environment
     try:


### PR DESCRIPTION
Add Python 3.12 to CI testing by switching all default jobs to 3.12. Python 3.9 to 3.11 is still tested.