### PR TITLE
change to log message and log level in feature scoring

### DIFF
--- a/ema_workbench/analysis/feature_scoring.py
+++ b/ema_workbench/analysis/feature_scoring.py
@@ -66,9 +66,7 @@ def _prepare_experiments(experiments):
     for column in x_nominal_columns:
         if np.unique(x[column]).shape == (1,):
             x = x.drop(column, axis=1)
-            _logger.info(
-                ("{} dropped from analysis " "because only a single category").format(column)
-            )
+            _logger.debug(f"{column} dropped from analysis because it has only a single category")
         else:
             x[column] = x[column].astype("category").cat.codes
 


### PR DESCRIPTION
fixes #261

columns with the same value for all entries don't matter for feature scoring, so they can be ignored.