### PR TITLE
Create an GitHub issue chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a Question or Seek Help
+    url: https://github.com/quaquel/EMAworkbench/discussions
+    about: "For questions or if you have an issue that you're not sure is caused by the EMAworkbench, please use our Discussions section."


### PR DESCRIPTION
With this, when users press the New issue button, they get a chooser where they can also choose to create a discussion.

In the future, we could also add templates for bug reports, feature request, etc. if we want.

See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository