### PR TITLE
Fix finalizer dependency on global experiment_runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ In the 2.5.0 release of the EMAworkbench we introduce a new experimental MPIeval
 Furthermore, the pair plots for scenario discovery now allow contour plots and bivariate histograms (#288). When doing Prim you can inspect multiple boxed and display them in a single figure (#317).
 
 ### Breaking changes
-From 3.0 onwards, the names of parameters, constants, constraints, and outcomes must be valid python identifiers. From this version onwards, a DeprecationWarning is raised if the name is not a valid Python identifier. 
+From 3.0 onwards, the names of parameters, constants, constraints, and outcomes must be valid python identifiers. From this version onwards, a DeprecationWarning is raised if the name is not a valid Python identifier.
 
 ### What's Changed
 #### 🎉 New features added

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -65,7 +65,7 @@ def mpi_initializer(models, log_level, root_dir):
     # setup the working directories
     tmpdir = setup_working_directories(models, root_dir)
     if tmpdir:
-        atexit.register(finalizer, os.path.abspath(tmpdir))
+        atexit.register(finalizer(experiment_runner), os.path.abspath(tmpdir))
 
     # _logger.info(f"worker {rank} initialized")
     root_logger.info(f"worker {rank} initialized")

--- a/ema_workbench/em_framework/futures_multiprocessing.py
+++ b/ema_workbench/em_framework/futures_multiprocessing.py
@@ -66,7 +66,7 @@ def initializer(*args):
     # remove the root temp
     if tmpdir:
         multiprocessing.util.Finalize(
-            None, finalizer, args=(os.path.abspath(tmpdir),), exitpriority=10
+            None, finalizer(experiment_runner), args=(os.path.abspath(tmpdir),), exitpriority=10
         )
 
 

--- a/ema_workbench/em_framework/futures_util.py
+++ b/ema_workbench/em_framework/futures_util.py
@@ -30,21 +30,23 @@ def determine_rootdir(msis):
     return root_dir
 
 
-def finalizer(tmpdir):
+def finalizer(experiment_runner):
     """cleanup"""
-    global experiment_runner
-    _logger.info("finalizing")
 
-    experiment_runner.cleanup()
-    del experiment_runner
+    def finalizer(tmpdir):
+        _logger.info("finalizing")
 
-    time.sleep(1)
+        experiment_runner.cleanup()
+        del experiment_runner
 
-    if tmpdir:
-        try:
-            shutil.rmtree(tmpdir)
-        except OSError:
-            pass
+        time.sleep(1)
+
+        if tmpdir:
+            try:
+                shutil.rmtree(tmpdir)
+            except OSError:
+                pass
+    return finalizer
 
 
 def setup_working_directories(models, root_dir):

--- a/ema_workbench/em_framework/futures_util.py
+++ b/ema_workbench/em_framework/futures_util.py
@@ -37,7 +37,7 @@ def finalizer(experiment_runner):
         _logger.info("finalizing")
 
         experiment_runner.cleanup()
-        del experiment_runner
+        # del experiment_runner
 
         time.sleep(1)
 
@@ -46,6 +46,7 @@ def finalizer(experiment_runner):
                 shutil.rmtree(tmpdir)
             except OSError:
                 pass
+
     return finalizer
 
 


### PR DESCRIPTION
The current finalizer in futures_util.py assumes that experiment_runner exists in the namespace of the module (i.e., .py file). However, this is only available in each of the separate futures models (i.e., multiprocessing, mpi). This fixes the resulting bug.