### PR TITLE
bug fix in MPI evaluator

### DIFF
--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -91,18 +91,45 @@ def logwatcher(stop_event):
     _logger.debug("client connected...")
 
     while not stop_event.is_set():
-        if rank == root:
-            record = comm.recv(None, MPI.ANY_SOURCE, tag=0)
+        record = comm.irecv(None, MPI.ANY_SOURCE, tag=0)
+        success = False
+        message = None
+        start_time = time.time()
+
+        while not success or (
+            (time.time() - start_time()) > 10
+        ):  # what is a good timeout number given initialization of worker processes?
+            success, message = record.test()
+            time.sleep(1)
+
+        if success:
             try:
-                logger = logging.getLogger(record.name)
+                logger = logging.getLogger(message.name)
             except Exception as e:
                 # AttributeError if record does not have a name attribute
                 # TypeError record.name is not a string
                 raise e
             else:
-                logger.callHandlers(record)
+                logger.callHandlers(message)
+        else:
+            record.cancel()
+            record.Free()
     else:
         _logger.info("closing logwatcher")
+
+    # while not stop_event.is_set():
+    #     if rank == root:
+    #         record = comm.recv(None, MPI.ANY_SOURCE, tag=0)
+    #         try:
+    #             logger = logging.getLogger(record.name)
+    #         except Exception as e:
+    #             # AttributeError if record does not have a name attribute
+    #             # TypeError record.name is not a string
+    #             raise e
+    #         else:
+    #             logger.callHandlers(record)
+    # else:
+    #     _logger.info("closing logwatcher")
 
 
 def run_experiment_mpi(experiment):

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -106,8 +106,8 @@ def logwatcher(stop_event):
                     raise e
             else:
                 logger.callHandlers(record)
-    else:
-        _logger.info("closing logwatcher")
+
+    _logger.info("closing logwatcher")
 
 
 def run_experiment_mpi(experiment):
@@ -126,7 +126,6 @@ def send_sentinel():
     for handler in get_rootlogger().handlers:
         if isinstance(handler, MPIHandler):
             _logger.debug("sending sentinel")
-            # handler.emit(record)
             handler.communicator.send(record, 0, 0)
 
 

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -126,7 +126,8 @@ def send_sentinel():
     for handler in get_rootlogger().handlers:
         if isinstance(handler, MPIHandler):
             _logger.debug("sending sentinel")
-            handler.emit(record)
+            # handler.emit(record)
+            handler.communicator.send(record, 0, 0)
 
 
 class MPIHandler(QueueHandler):

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -148,11 +148,11 @@ def run_experiment_mpi(experiment):
 
 
 def send_sentinel():
-    record = logging.makeLogRecord({})
-    _logger.info("sending sentinel")
+    record = logging.makeLogRecord(dict(level=logging.CRITICAL, msg=None))
 
     for handler in _logger.handlers:
         if isinstance(handler, MPIHandler):
+            _logger.info("sending sentinel")
             handler.emit(record)
 
 

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -169,9 +169,8 @@ class MPIEvaluator(BaseEvaluator):
             max_workers=self.n_processes,
             initializer=mpi_initializer,
             initargs=(self._msis, _logger.level, self.root_dir),
-        )  # Removed initializer arguments
+        )
 
-        self._pool = MPIPoolExecutor(max_workers=self.n_processes)  # Removed initializer arguments
         _logger.info(f"MPI pool started with {self._pool._max_workers} workers")
         if self._pool._max_workers <= 10:
             _logger.warning(

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -225,10 +225,9 @@ class MPIEvaluator(BaseEvaluator):
     @method_logger(__name__)
     def finalize(self):
         # submit sentinel
-        f = self._pool.submit(send_sentinel)
-
-        self._pool.shutdown()
         self.stop_event.set()
+        self._pool.submit(send_sentinel)
+        self._pool.shutdown()
         self.logwatcher_thread.join(timeout=60)
 
         if self.logwatcher_thread.is_alive():

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -152,7 +152,7 @@ def send_sentinel():
 
     for handler in get_rootlogger().handlers:
         if isinstance(handler, MPIHandler):
-            _logger.info("sending sentinel")
+            _logger.debug("sending sentinel")
             handler.emit(record)
 
 

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -96,9 +96,8 @@ def logwatcher(stop_event):
             try:
                 logger = logging.getLogger(record.name)
             except Exception as e:
-                _logger.info(repr(record))
                 if record.msg is None:
-                    _logger.info("received sentinel")
+                    _logger.debug("received sentinel")
                     break
                 else:
                     # AttributeError if record does not have a name attribute

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -188,6 +188,7 @@ class MPIEvaluator(BaseEvaluator):
         )
         self.logwatcher_thread.start()
         start_event.wait()
+        _logger.info("logwatcher server started")
 
         self.root_dir = determine_rootdir(self._msis)
         self._pool = MPIPoolExecutor(

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -14,7 +14,7 @@ from .futures_util import setup_working_directories, finalizer, determine_rootdi
 from .util import NamedObjectMap
 from .model import AbstractModel
 from .experiment_runner import ExperimentRunner
-from ..util import get_module_logger, get_rootlogger
+from ..util import get_module_logger, get_rootlogger, method_logger
 
 from ..util import ema_logging
 
@@ -154,6 +154,7 @@ class MPIEvaluator(BaseEvaluator):
         self.stop_event = None
         self.n_processes = n_processes
 
+    @method_logger(__name__)
     def initialize(self):
         # Only import mpi4py if the MPIEvaluator is used, to avoid unnecessary dependencies.
         from mpi4py.futures import MPIPoolExecutor
@@ -178,6 +179,7 @@ class MPIEvaluator(BaseEvaluator):
             )
         return self
 
+    @method_logger(__name__)
     def finalize(self):
         self._pool.shutdown()
         self.stop_event.set()
@@ -189,6 +191,7 @@ class MPIEvaluator(BaseEvaluator):
         time.sleep(0.1)
         _logger.info("MPI pool has been shut down")
 
+    @method_logger(__name__)
     def evaluate_experiments(self, scenarios, policies, callback, combine="factorial", **kwargs):
         ex_gen = experiment_generator(scenarios, self._msis, policies, combine=combine)
         experiments = list(ex_gen)

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -101,6 +101,8 @@ def logwatcher(stop_event):
                 raise e
             else:
                 logger.callHandlers(record)
+    else:
+        _logger.debug("closing logwatchter")
 
 
 def run_experiment_mpi(experiment):

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -150,7 +150,7 @@ def run_experiment_mpi(experiment):
 def send_sentinel():
     record = logging.makeLogRecord(dict(level=logging.CRITICAL, msg=None))
 
-    for handler in _logger.handlers:
+    for handler in get_rootlogger().handlers:
         if isinstance(handler, MPIHandler):
             _logger.info("sending sentinel")
             handler.emit(record)

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -102,7 +102,7 @@ def logwatcher(stop_event):
             else:
                 logger.callHandlers(record)
     else:
-        _logger.debug("closing logwatchter")
+        _logger.info("closing logwatcher")
 
 
 def run_experiment_mpi(experiment):

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -90,46 +90,19 @@ def logwatcher(stop_event):
     comm = MPI.COMM_WORLD.Accept(port, info, root)
     _logger.debug("client connected...")
 
-    # while not stop_event.is_set():
-    #     record = comm.irecv(None, MPI.ANY_SOURCE, tag=0)
-    #     success = False
-    #     message = None
-    #     start_time = time.time()
-    #
-    #     while not success or (
-    #         (time.time() - start_time) > 10
-    #     ):  # what is a good timeout number given initialization of worker processes?
-    #         success, message = record.test()
-    #         time.sleep(1)
-    #
-    #     if success:
-    #         try:
-    #             logger = logging.getLogger(message.name)
-    #         except Exception as e:
-    #             # AttributeError if record does not have a name attribute
-    #             # TypeError record.name is not a string
-    #             raise e
-    #         else:
-    #             logger.callHandlers(message)
-    #     else:
-    #         record.cancel()
-    #         record.Free()
-    # else:
-    #     _logger.info("closing logwatcher")
-
     while not stop_event.is_set():
         if rank == root:
             record = comm.recv(None, MPI.ANY_SOURCE, tag=0)
             try:
                 logger = logging.getLogger(record.name)
             except Exception as e:
+                _logger.info(repr(record))
                 if record.msg is None:
                     _logger.info("received sentinel")
                     break
                 else:
                     # AttributeError if record does not have a name attribute
                     # TypeError record.name is not a string
-                    _logger.info("some exception {e}")
                     raise e
             else:
                 logger.callHandlers(record)

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -121,7 +121,7 @@ def run_experiment_mpi(experiment):
 
 
 def send_sentinel():
-    record = logging.makeLogRecord(dict(level=logging.CRITICAL, msg=None))
+    record = logging.makeLogRecord(dict(level=logging.CRITICAL, msg=None, name=42))
 
     for handler in get_rootlogger().handlers:
         if isinstance(handler, MPIHandler):

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -97,7 +97,7 @@ def logwatcher(stop_event):
         start_time = time.time()
 
         while not success or (
-            (time.time() - start_time()) > 10
+            (time.time() - start_time) > 10
         ):  # what is a good timeout number given initialization of worker processes?
             success, message = record.test()
             time.sleep(1)

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -129,6 +129,7 @@ def logwatcher(stop_event):
                 else:
                     # AttributeError if record does not have a name attribute
                     # TypeError record.name is not a string
+                    _logger.info("some exception {e}")
                     raise e
             else:
                 logger.callHandlers(record)
@@ -148,6 +149,7 @@ def run_experiment_mpi(experiment):
 
 def send_sentinel():
     record = logging.makeLogRecord({})
+    _logger.info("sending sentinel")
 
     for handler in _logger.handlers:
         if isinstance(handler, MPIHandler):
@@ -223,7 +225,7 @@ class MPIEvaluator(BaseEvaluator):
     @method_logger(__name__)
     def finalize(self):
         # submit sentinel
-        self._pool.submit(send_sentinel)
+        f = self._pool.submit(send_sentinel)
 
         self._pool.shutdown()
         self.stop_event.set()
@@ -231,8 +233,6 @@ class MPIEvaluator(BaseEvaluator):
 
         if self.logwatcher_thread.is_alive():
             _logger.warning(f"houston we have a problem")
-
-        _logger.info("MPI pool has been shut down")
 
         if self.root_dir:
             shutil.rmtree(self.root_dir)

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -223,7 +223,7 @@ class MPIEvaluator(BaseEvaluator):
     @method_logger(__name__)
     def finalize(self):
         # submit sentinel
-        self._pool.submit()
+        self._pool.submit(send_sentinel)
 
         self._pool.shutdown()
         self.stop_event.set()

--- a/ema_workbench/examples/example_mpi_lake_model.py
+++ b/ema_workbench/examples/example_mpi_lake_model.py
@@ -83,10 +83,13 @@ def lake_problem(
 
 
 if __name__ == "__main__":
+    import ema_workbench
+
     # run with mpiexec -n 1 -usize {ntasks} python example_mpi_lake_model.py
     starttime = time.perf_counter()
 
     ema_logging.log_to_stderr(ema_logging.INFO, pass_root_logger_level=True)
+    ema_logging.get_rootlogger().info(f"{ema_workbench.__version__}")
 
     # instantiate the model
     lake_model = Model("lakeproblem", function=lake_problem)

--- a/ema_workbench/examples/example_mpi_lake_model.py
+++ b/ema_workbench/examples/example_mpi_lake_model.py
@@ -9,11 +9,6 @@ see https://gist.github.com/dhadka/a8d7095c98130d8f73bc
 import math
 import time
 
-# FIXME
-import sys
-
-sys.path.insert(0, "/Users/jhkwakkel/Documents/GitHub/EMAworkbench")
-
 import numpy as np
 from scipy.optimize import brentq
 

--- a/ema_workbench/examples/slurm_script.sh
+++ b/ema_workbench/examples/slurm_script.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --job-name="Python_test"
 #SBATCH --time=00:06:00
-#SBATCH --ntasks=10
+#SBATCH --ntasks=8
 #SBATCH --cpus-per-task=1
 #SBATCH --partition=compute
 #SBATCH --mem-per-cpu=4GB
@@ -17,6 +17,7 @@ module load py-mpi4py
 module load py-pip
 
 pip install ipyparallel
-pip install --user ema_workbench
+pip install --user -e git+https://github.com/quaquel/EMAworkbench@mpi_fixes#egg=ema_workbench
 
 mpiexec -n 1 python3 example_mpi_lake_model.py
+

--- a/ema_workbench/examples/slurm_script.sh
+++ b/ema_workbench/examples/slurm_script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #SBATCH --job-name="Python_test"
-#SBATCH --time=00:02:00
+#SBATCH --time=00:06:00
 #SBATCH --ntasks=10
 #SBATCH --cpus-per-task=1
 #SBATCH --partition=compute
@@ -17,6 +17,6 @@ module load py-mpi4py
 module load py-pip
 
 pip install ipyparallel
-pip install --user -e git+https://github.com/quaquel/EMAworkbench@mpi_update#egg=ema-workbench
+pip install --user ema_workbench
 
 mpiexec -n 1 python3 example_mpi_lake_model.py


### PR DESCRIPTION
Fixes a mistake in the MPI evaluator where the pool is created twice (probably some code merging issue in the past)

It also cleans up the mpi example and associated slurm file.


NB: this code segfaults on DelftBlue during shut down. I still need to investigate this. It seems related to the treading used for handling logging. 