### PR TITLE
Drop Python 3.9 support, require 3.10+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.10"
           - os: ubuntu-latest
-            python-version: "3.9"
-          - os: ubuntu-latest
             python-version: "3.12"
             pip-pre: "--pre"  # Installs pre-release versions of pip dependencies
             name: "Pre-release dependencies"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,10 @@ repos:
     hooks:
       - id: black-jupyter
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.1
+    rev: v3.15.2
     hooks:
     -   id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0  # Use the ref you want to point at
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "Exploratory modelling in Python"
 readme = "README.md"
 license = { file="LICENSE.md" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers=[
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Following [SPEC 0](https://scientific-python.org/specs/spec-0000/) Python 3.9 support is dropped for future minor and major releases, and will require Python 3.10+ from version 3.0 onwards.

The main benefit of requiring Python 3.10 is that we can implement type hinting more elegant in the workbench.

The 2.5.x branch will keep supporting Python 3.9.