### PR TITLE
CI: Uses uv pip to speed up workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,13 @@ jobs:
     - run: pip install uv
     - name: Install dependencies
       run: |
-        uv pip install --upgrade pip
-        uv pip install .[dev,cov] ${{ matrix.pip-pre }}
+        uv pip install .[dev,cov] --system ${{ matrix.pip-pre }}
     - name: Install MPI and mpi4py
       if: matrix.test-mpi == true
       run: |
         sudo apt-get update
         sudo apt-get install -y libopenmpi-dev
-        uv pip install mpi4py
+        uv pip install mpi4py --system
     - name: Test with Pytest
       timeout-minutes: 15
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,18 +39,17 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: 'pyproject.toml'
+    - run: pip install uv
     - name: Install dependencies
       run: |
-        pip install --upgrade pip
-        pip install .[dev,cov] ${{ matrix.pip-pre }}
+        uv pip install --upgrade pip
+        uv pip install .[dev,cov] ${{ matrix.pip-pre }}
     - name: Install MPI and mpi4py
       if: matrix.test-mpi == true
       run: |
         sudo apt-get update
         sudo apt-get install -y libopenmpi-dev
-        pip install mpi4py
+        uv pip install mpi4py
     - name: Test with Pytest
       timeout-minutes: 15
       run:


### PR DESCRIPTION
Use uv for pip commands to speed up CI workflows. uv uses Rust to install dependencies way faster.

On Ubuntu and macOS it reduces dependency install time from ~30 sec to <10 sec, and on Windows from ~2 min to <1 min.

Squash on merge.