### PR TITLE
CI: Add test job for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
             python-version: "3.12"
             pip-pre: "--pre"  # Installs pre-release versions of pip dependencies
             name: "Pre-release dependencies"
+          - os: ubuntu-latest
+            python-version: "3.13"
 
     steps:
     - uses: actions/checkout@v4
@@ -37,6 +39,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - run: pip install uv
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Python 3.13 is now in beta, thus is might be useful to start testing what works and what doesn't.

This PR adds a Python 3.13 job on Ubuntu.