### PR TITLE
Update .readthedocs.yaml: Use latest Ubuntu and Python versions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3"
+    python: latest
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Use latest Ubuntu and Python versions for Readthedocs. These are faster and throw more detailed errors if anything goes wrong.