### PR TITLE
Use PlatypusConfig.default_variator

### DIFF
--- a/ema_workbench/em_framework/outputspace_exploration.py
+++ b/ema_workbench/em_framework/outputspace_exploration.py
@@ -27,7 +27,6 @@ from platypus import (
     RandomGenerator,
     Dominance,
     AbstractGeneticAlgorithm,
-    default_variator,
     AdaptiveTimeContinuation,
     GAOperator,
     SBX,
@@ -38,6 +37,7 @@ from platypus import (
     PCX,
     UNDX,
     Multimethod,
+    PlatypusConfig,
 )
 
 
@@ -186,7 +186,7 @@ class OutputSpaceExplorationAlgorithm(AbstractGeneticAlgorithm):
             self.archive += self.population
 
         if self.variator is None:
-            self.variator = default_variator(self.problem)
+            self.variator = PlatypusConfig.default_variator(self.problem)
 
     def iterate(self):
         offspring = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pandas",
     "scikit-learn",
     "salib>=1.4.6",
-    "platypus-opt",
+    "platypus-opt>=1.3.0",
     "matplotlib",
     "statsmodels",
     "seaborn",


### PR DESCRIPTION
Version `1.3.0` moved `default_variator` from a standalone method to part of `PlatypusConfig`.  Thus, this updates the method reference and puts a minimum version on the dependency.

Alternatively, if you want to allow either version, you could use something like:

```python

def default_variator(problem):
    try:
        return PlatypusConfig.default_variator(problem)
    except AttributeError:
        from platypus import default_variator
        return default_variator(problem)
```