### PR TITLE
Fixes for various warning during tests

### DIFF
--- a/ema_workbench/analysis/dimensional_stacking.py
+++ b/ema_workbench/analysis/dimensional_stacking.py
@@ -405,7 +405,9 @@ def create_pivot_plot(x, y, nr_levels=3, labels=True, categories=True, nbins=3, 
     ooi = pd.DataFrame(y[:, np.newaxis], columns=[ooi_label])
 
     x_y_concat = pd.concat([discretized_x, ooi], axis=1)
-    pvt = pd.pivot_table(x_y_concat, values=ooi_label, index=rows, columns=columns, dropna=False)
+    pvt = pd.pivot_table(
+        x_y_concat, values=ooi_label, index=rows, columns=columns, dropna=False, observed=False
+    )
 
     fig = plot_pivot_table(pvt, plot_labels=labels, plot_cats=categories)
 

--- a/ema_workbench/analysis/logistic_regression.py
+++ b/ema_workbench/analysis/logistic_regression.py
@@ -64,7 +64,7 @@ def calculate_covden_for_treshold(predicted, y, threshold):
     fp = np.sum(((predicted > threshold) == True) & (y == False))
     fn = np.sum(((predicted > threshold) == False) & (y == True))
 
-    precision = tp / (tp + fp)
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
     recall = tp / (tp + fn)
 
     return precision, recall

--- a/ema_workbench/analysis/scenario_discovery_util.py
+++ b/ema_workbench/analysis/scenario_discovery_util.py
@@ -926,7 +926,7 @@ class OutputFormatterMixin:
             for unc in uncs:
                 values = box.loc[:, unc]
                 values = values.rename({0: "min", 1: "max"})
-                df_boxes.loc[unc][index[i]] = values.values
+                df_boxes.loc[unc, index[i]] = values.values
         return df_boxes
 
     def stats_to_dataframe(self):

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -30,7 +30,6 @@ try:
         Real,
         Integer,
         Subset,
-        EpsilonProgressContinuation,
         RandomGenerator,
         TournamentSelector,
         NSGAII,
@@ -47,6 +46,7 @@ try:
         Solution,
         InvertedGenerationalDistance,
         Spacing,
+        EpsilonProgressContinuationExtension,
     )  # @UnresolvedImport
     from platypus import Problem as PlatypusProblem
 
@@ -1126,7 +1126,7 @@ class BORGDefaultDescriptor:
         self.name = name
 
 
-class GenerationalBorg(EpsilonProgressContinuation):
+class GenerationalBorg(EpsilonProgressContinuationExtension):
     """A generational implementation of the BORG Framework
 
     This algorithm adopts Epsilon Progress Continuation, and Auto Adaptive

--- a/ema_workbench/em_framework/outputspace_exploration.py
+++ b/ema_workbench/em_framework/outputspace_exploration.py
@@ -28,7 +28,6 @@ from platypus import (
     Dominance,
     AbstractGeneticAlgorithm,
     default_variator,
-    AdaptiveTimeContinuation,
     GAOperator,
     SBX,
     PM,
@@ -39,6 +38,7 @@ from platypus import (
     UNDX,
     Multimethod,
     PlatypusConfig,
+    AdaptiveTimeContinuationExtension,
 )
 
 
@@ -247,7 +247,7 @@ def get_bin_index(value, minumum_value, epsilon):
     return math.floor((value - minumum_value) / epsilon)
 
 
-class OutputSpaceExploration(AdaptiveTimeContinuation):
+class OutputSpaceExploration(AdaptiveTimeContinuationExtension):
     """Basic genetic algorithm for output space exploration using novelty
     search.
 
@@ -304,7 +304,7 @@ class OutputSpaceExploration(AdaptiveTimeContinuation):
         )
 
 
-class AutoAdaptiveOutputSpaceExploration(AdaptiveTimeContinuation):
+class AutoAdaptiveOutputSpaceExploration(AdaptiveTimeContinuationExtension):
     """A combination of auto-adaptive operator selection with OutputSpaceExploration.
 
     The parametrization of all operators is based on the default values as used

--- a/ema_workbench/em_framework/outputspace_exploration.py
+++ b/ema_workbench/em_framework/outputspace_exploration.py
@@ -38,6 +38,7 @@ from platypus import (
     PCX,
     UNDX,
     Multimethod,
+    PlatypusConfig,
 )
 
 
@@ -186,7 +187,7 @@ class OutputSpaceExplorationAlgorithm(AbstractGeneticAlgorithm):
             self.archive += self.population
 
         if self.variator is None:
-            self.variator = default_variator(self.problem)
+            self.variator = PlatypusConfig.default_variator(self.problem)
 
     def iterate(self):
         offspring = []

--- a/test/test_analysis/test_logistic_regression.py
+++ b/test/test_analysis/test_logistic_regression.py
@@ -35,7 +35,7 @@ class LogitTestCase(unittest.TestCase):
         for entry in logitmodel.feature_names:
             self.assertIn(entry, columns)
 
-        logitmodel.run(method="newton", maxiter=10)
+        logitmodel.run(method="newton", maxiter=5)
 
         logitmodel.show_tradeoff()
         logitmodel.show_threshold_tradeoff(1)

--- a/test/test_analysis/test_logistic_regression.py
+++ b/test/test_analysis/test_logistic_regression.py
@@ -35,7 +35,7 @@ class LogitTestCase(unittest.TestCase):
         for entry in logitmodel.feature_names:
             self.assertIn(entry, columns)
 
-        logitmodel.run(method="newton", maxiter=2)
+        logitmodel.run(method="newton", maxiter=100)
 
         logitmodel.show_tradeoff()
         logitmodel.show_threshold_tradeoff(1)

--- a/test/test_analysis/test_logistic_regression.py
+++ b/test/test_analysis/test_logistic_regression.py
@@ -35,7 +35,7 @@ class LogitTestCase(unittest.TestCase):
         for entry in logitmodel.feature_names:
             self.assertIn(entry, columns)
 
-        logitmodel.run(method="newton", maxiter=100)
+        logitmodel.run(method="newton", maxiter=10)
 
         logitmodel.show_tradeoff()
         logitmodel.show_threshold_tradeoff(1)

--- a/test/test_analysis/test_logistic_regression.py
+++ b/test/test_analysis/test_logistic_regression.py
@@ -37,8 +37,9 @@ class LogitTestCase(unittest.TestCase):
         for entry in logitmodel.feature_names:
             self.assertIn(entry, columns)
 
-        warnings.filterwarnings("ignore", category=ConvergenceWarning)
-        logitmodel.run(method="newton", maxiter=2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            logitmodel.run(method="newton", maxiter=2)
 
         logitmodel.show_tradeoff()
         logitmodel.show_threshold_tradeoff(1)

--- a/test/test_analysis/test_logistic_regression.py
+++ b/test/test_analysis/test_logistic_regression.py
@@ -38,7 +38,7 @@ class LogitTestCase(unittest.TestCase):
             self.assertIn(entry, columns)
 
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+            warnings.simplefilter("ignore", category=ConvergenceWarning)
             logitmodel.run(method="newton", maxiter=2)
 
         logitmodel.show_tradeoff()

--- a/test/test_analysis/test_logistic_regression.py
+++ b/test/test_analysis/test_logistic_regression.py
@@ -4,6 +4,7 @@ Created on 16 Mar 2019
 @author: jhkwakkel
 """
 
+import warnings
 import unittest
 
 import matplotlib.pyplot as plt
@@ -12,6 +13,7 @@ import pandas as pd
 
 from ema_workbench.analysis import logistic_regression as lr
 from test import utilities
+from statsmodels.tools.sm_exceptions import ConvergenceWarning
 
 
 def flu_classify(data):
@@ -35,7 +37,8 @@ class LogitTestCase(unittest.TestCase):
         for entry in logitmodel.feature_names:
             self.assertIn(entry, columns)
 
-        logitmodel.run(method="newton", maxiter=5)
+        warnings.filterwarnings("ignore", category=ConvergenceWarning)
+        logitmodel.run(method="newton", maxiter=2)
 
         logitmodel.show_tradeoff()
         logitmodel.show_threshold_tradeoff(1)

--- a/test/test_analysis/test_prim.py
+++ b/test/test_analysis/test_prim.py
@@ -385,7 +385,7 @@ class PrimTestCase(unittest.TestCase):
             self.assertTrue(isinstance(tempbox, pd.DataFrame))
 
         # have modified boxlims as starting point
-        x.a[x.a > 5] = 5
+        x.loc[x.a > 5, "a"] = 5
         primalg = prim.Prim(x, y, threshold=0.8)
         boxlims = primalg.box_init
         boxlims.a = [5, 8]
@@ -394,7 +394,7 @@ class PrimTestCase(unittest.TestCase):
         peels = primalg._discrete_peel(box, "a", 0, primalg.x_int)
         self.assertEqual(len(peels), 2)
 
-        x.a[x.a < 5] = 5
+        x.loc[x.a < 5, "a"] = 5
         primalg = prim.Prim(x, y, threshold=0.8)
         boxlims = primalg.box_init
         boxlims.a = [5, 8]


### PR DESCRIPTION
This PR combines a bunch of small changes that fix specific warnings issued during unit tests. Most of these have to do with future warnings and deprecation warnings. 

Each commit fixes a specific warning with the message detailing what is addressed. 

This PR targets 2.5, but should be merged into master afterwards as well. I focus on 2.5 since that is used in teaching at the moment. 