### PR TITLE
minor fix to avoid error of directory already exists while using Mult…

### DIFF
--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -675,7 +675,6 @@ class ArchiveLogger(AbstractConvergenceMetric):
     ):
         super().__init__("archive_logger")
 
-
         self.directory = os.path.abspath(directory)
         self.temp = os.path.join(self.directory, "tmp")
         os.makedirs(self.temp, exist_ok=True)

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -675,10 +675,10 @@ class ArchiveLogger(AbstractConvergenceMetric):
     ):
         super().__init__("archive_logger")
 
-        # FIXME how to handle case where directory already exists
+
         self.directory = os.path.abspath(directory)
         self.temp = os.path.join(self.directory, "tmp")
-        os.mkdir(self.temp)
+        os.makedirs(self.temp, exist_ok=True)
 
         self.base = base_filename
         self.decision_varnames = decision_varnames


### PR DESCRIPTION
When using ArchiveLogger with multiprocessing, a FileExistsError may occur if multiple processes attempt to create the same tmp directory using os.mkdir. This PR fixes the issue by replacing `os.mkdir(self.temp)` with `os.makedirs(self.temp, exist_ok=True)`, which avoids errors if the directory already exists.

Error before this fix:

```
FileExistsError: [Errno 17] File exists: '.../tmp'
```
Summary of change:

Replaced `os.mkdir(self.temp) ` with `os.makedirs(self.temp, exist_ok=True)` in ArchiveLogger class inside optimization.py.