### PR TITLE
Remove lookup uncertainty

### DIFF
--- a/ema_workbench/connectors/vensim.py
+++ b/ema_workbench/connectors/vensim.py
@@ -28,7 +28,6 @@ from .vensimDLLwrapper import VensimError, VensimWarning, command, get_val
 # .. codeauthor:: jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
 
 __all__ = [
-    "LookupUncertainty",
     "VensimModel",
     "be_quiet",
     "get_data",
@@ -230,8 +229,6 @@ class VensimModel(SingleReplication, FileModel):
         super().__init__(name, wd=wd, model_file=model_file)
         self.outcomes.extend(TimeSeriesOutcome("TIME", variable_name="Time"))
 
-        self._lookup_uncertainties = NamedObjectMap(Parameter)
-
         #: attribute that can be set when one wants to load a cin file
         self.cin_file = None
 
@@ -292,12 +289,8 @@ class VensimModel(SingleReplication, FileModel):
     def run_experiment(self, experiment: Experiment):
         """Run the experiment.
 
-        The provided implementation assumes that the keys in the
-        case match the variable names in the Vensim model.
-
-        If lookups are to be set specify their transformation from
-        uncertainties to lookup values in the extension of this method,
-        then call this one using super with the updated case dict.
+        The provided implementation assumes that the keys (i.e., the parameter names) in the
+        experiment match the variable names in the Vensim model.
 
         if you want to use cin_files, set the cin_file, or cin_files in
         the extension of this method to `self.cin_file`.
@@ -320,13 +313,6 @@ class VensimModel(SingleReplication, FileModel):
                 _logger.debug(str(w))
             else:
                 _logger.debug("cin file read successfully")
-
-        for lookup_uncertainty in self._lookup_uncertainties:
-            # ask the lookup to transform the retrieved uncertainties to the
-            # proper lookup value
-            experiment[lookup_uncertainty.name] = lookup_uncertainty.transform(
-                experiment
-            )
 
         for key, value in experiment.items():
             set_value(key, value)
@@ -366,308 +352,6 @@ class VensimModel(SingleReplication, FileModel):
             raise CaseError("run not completed", experiment)
 
         return results
-
-    def _delete_lookup_uncertainties(self):
-        """Delete lookup uncertainties from the uncertainty list."""
-        self._lookup_uncertainties = self._lookup_uncertainties[:]
-        self.uncertainties = [
-            x for x in self.uncertainties if x not in self._lookup_uncertainties
-        ]
-
-
-class LookupUncertainty(Parameter):
-    """Convenience class to do sensitivity analysis on lookups."""
-
-    HEARNE1 = "hearne1"
-    HEARNE2 = "hearne2"
-    APPROX = "approximation"
-    CAT = "categories"
-
-    error_message = "unknown transform_type for lookup uncertainty {}"
-    msi = None
-    y_min = None
-    y_max = None
-    x_min = None
-    x_max = None
-    x = []
-    y = []
-
-    def __init__(self, lookup_type, values, name, msi, ymin=None, ymax=None):
-        """Init.
-
-        Parameters
-        ----------
-        lookup_type : {'categories', 'hearne', 'approximation'}
-                      the method to be used for alternative generation.
-        values : collection
-                 the values for specifying the uncertainty from which to
-                 sample.
-            If 'lookup_type' is "categories", a set of alternative lookup
-                functions to  be entered as tuples of x,y points.
-                Example definition:
-                LookupUncertainty([[(0.0, 0.05), (0.25, 0.15), (0.5, 0.4),
-                                    (0.75, 1), (1, 1.25)],
-                                  [(0.0, 0.1), (0.25, 0.25), (0.5, 0.75),
-                                   (1, 1.25)],
-                                  [(0.0, 0.0), (0.1, 0.2), (0.3, 0.6),
-                                   (0.6, 0.9), (1, 1.25)]],
-                                   "TF3", 'categories', self )
-            if 'lookup_type' is "hearne1", a list of ranges for each parameter
-                Single-extreme piecewise functions
-                m: maximum deviation from l of the distortion function
-                p: the point that this occurs
-                l: lower end point
-                u: upper end point
-            If 'lookup_type' is "hearne2", a list of ranges for each
-                parameter. Double extreme piecewise linear functions with
-                variable endpoints are used to distort the lookup functions.
-                These functions are defined by 6 parameters, being m1, m2, p1,
-                p2, l and u; and the uncertainty ranges for these 6 parameters
-                should  be given as the values of this lookup uncertainty if
-                Hearne's method is chosen. The meaning of these parameters is
-                simply:
-                m1: maximum deviation (peak if positive, bottom if negative) of
-                 the distortion function from l in the first segment
-                p1: where this peak occurs in the x axis
-                m2: maximum deviation of the distortion function from l or u in
-                    the second segment
-                p2: where the second peak/bottom occurs
-                l : lower end point, namely the y value for x_min
-                u : upper end point, namely the y value for x_max
-                Example definition:
-                LookupUncertainty([(-1, 2), (-1, 1), (0, 1), (0, 1), (0, 0.5),
-                                   (0.5, 1.5)], "TF2", 'hearne', self, 0, 2)
-             If 'lookup_type' is "approximation", an analytical function
-                 approximation (a logistic function) will be used, instead of a
-                 lookup. This function also has 6 parameters whose ranges should
-                 be given:
-                 A: the lower asymptote
-                 K: the upper asymptote
-                 B: the growth rate
-                 Q: depends on the value y(0)
-                 M: the time of maximum growth if Q=v
-        name : str
-               name of the uncertainty
-        msi : VensimModel instance
-              model structure interface, to be used for adding new
-              parameter uncertainties
-        min : float
-              min value the lookup function can take, this argument is
-              not needed in case of CAT
-        max : float
-              max value the lookup function can take, this argument is
-              not needed in case of CAT
-
-        """
-        super().__init__(values, name)
-        self.lookup_type = lookup_type
-        self.y_min = ymin
-        self.y_max = ymax
-        self.error_message = self.error_message.format(self.name)
-        self.transform_functions = {
-            self.HEARNE1: self._hearne1,
-            self.HEARNE2: self._hearne2,
-            self.APPROX: self._approx,
-            self.CAT: self._cat,
-        }
-
-        if self.lookup_type == "categories":
-            msi.uncertainties.append(
-                CategoricalParameter("c-" + self.name), range(len(values))
-            )
-            msi._lookup_uncertainties.append(self)
-        elif self.lookup_type == "hearne1":
-            msi.uncertainties.append(RealParameter("m-" + self.name, *values[0]))
-            msi.uncertainties.append(RealParameter("p-" + self.name, *values[1]))
-            msi.uncertainties.append(RealParameter("l-" + self.name, *values[2]))
-            msi.uncertainties.append(RealParameter("u-" + self.name, *values[3]))
-            msi._lookup_uncertainties.append(self)
-        elif self.lookup_type == "hearne2":
-            msi.uncertainties.append(RealParameter("m1-" + self.name), *values[0])
-            msi.uncertainties.append(RealParameter("m2-" + self.name, *values[1]))
-            msi.uncertainties.append(RealParameter("p1-" + self.name, *values[2]))
-            msi.uncertainties.append(RealParameter("p2-" + self.name, *values[3]))
-            msi.uncertainties.append(RealParameter("l-" + self.name, *values[4]))
-            msi.uncertainties.append(RealParameter("u-" + self.name, values[5]))
-            msi._lookup_uncertainties.append(self)
-        elif self.lookup_type == "approximation":
-            for i, entry in enumerate("A,K,B,Q,M"):
-                name = f"{entry}-{self.name}"
-                msi.uncertainties.append(RealParameter(name, *values[i]))
-            msi._lookup_uncertainties.append(self)
-        else:
-            raise EMAError(self.error_message)
-
-    def _get_initial_lookup(self, name):
-        """Retrieve the lookup function as defined in the vensim model.
-
-        This lookup is transformed using a distortion function.
-
-        Parameters
-        ----------
-        name : str
-               name of variable in vensim model that contains the lookup
-
-        """
-        a = vensimDLLwrapper.get_varattrib(name, 3)[0]
-        elements = a.split("],", 1)
-        b = elements[1][0:-1]
-
-        list1 = []
-        list2 = []
-        number = []
-        for c in b:
-            if c not in ("(", ")"):
-                list1.append(c)
-
-        list1.append(",")
-        for c in list1:
-            if c != ",":
-                number.append(c)
-            else:
-                list2.append(float("".join(number)))
-                number[:] = []
-        x = []
-        y = []
-        x_t = True
-        for i in list2:
-            if x_t:
-                x.append(i)
-                x_t = False
-            else:
-                y.append(i)
-                x_t = True
-        return x, y
-
-    def _gen_log(self, t, A, K, B, Q, M): # noqa: N803
-        """Create a logistic function, helper method.
-
-        Parameters
-        ----------
-        t : float
-        A : float
-        K : float
-        B : float
-        Q : float
-        M : float
-
-        """
-        decimal.getcontext().prec = 3
-        ex = math.exp(-B)
-        res = A + ((K - A) / (1 + Q * pow(ex, t) / pow(ex, M)))
-        return res
-
-    def transform(self, case): # noqa D102
-        if not self.x:
-            # first time transform is called
-            self.x, self.y = self._get_initial_lookup(self.name)
-            self.x_min = min(self.x)
-            self.x_max = max(self.x)
-        try:
-            func = self.transform_functions[self.lookup_type]
-
-            return func(case)
-        except KeyError as e:
-            raise EMAError(self.error_message) from e
-
-    def identity(self):
-        """HReturns the elements that uniquely define an uncertainty.
-
-        By default these are the name, the lower value of the range and the
-        upper value of the range.
-
-        """
-        # TODO this identity function is tricky. Identity is dependent on
-        # the exact transform lookup_type
-        return (self.name, self.values[0], self.values[1])
-
-    def _hearne1(self, case):
-        m = case["m-" + self.name]
-        p = case["p-" + self.name]
-        l = case["l-" + self.name] # noqa: E741
-        u = case["u-" + self.name]
-
-        for char in ["m-", "p-", "l-", "u-"]:
-            case.pop(char + self.name)
-
-        df = []
-        for i in self.x:
-            if i < p:
-                df.append(l + ((m / (p - self.x_min)) * i))
-            else:
-                df.append(l + m - ((m + l - u) * (i - p) / (self.x_min - p)))
-        new_lookup = []
-        for i in range(len(self.x)):
-            new_lookup.append(
-                (self.x[i], max(min(df[i] * self.y[i], self.y_max), self.y_min))
-            )
-        return new_lookup
-
-    def _hearne2(self, case):
-        m1 = case["m1-" + self.name]
-        m2 = case["m2-" + self.name]
-        p1 = case["p1-" + self.name]
-        p2 = case["p2-" + self.name]
-        l = case["l-" + self.name] # noqa: E741
-        u = case["u-" + self.name]
-
-        for char in ["m1-", "m2-", "p1-", "p2-", "l-", "u-"]:
-            case.pop(char + self.name)
-
-        df = []  # distortion function
-        for i in self.x:
-            if i < p1:
-                df.append(l + ((m1 / (p1 - self.x_min)) * i))
-            else:
-                if i < p2:
-                    df.append(l + m1 - ((m1 - m2 + l - u) * (i - p1) / (p2 - p1)))
-                else:
-                    df.append(u + m2 - (m2 * (i - p2) / (self.x_max - p2)))
-        new_lookup = []
-        for i in range(len(self.x)):
-            new_lookup.append(
-                (self.x[i], max(min(df[i] * self.y[i], self.y_max), self.y_min))
-            )
-        return new_lookup
-
-    def _approx(self, case):
-        A = case["A-" + self.name] # noqa: N806
-        K = case["K-" + self.name] # noqa: N806
-        B = case["B-" + self.name] # noqa: N806
-        Q = case["Q-" + self.name] # noqa: N806
-        M = case["M-" + self.name] # noqa: N806
-
-        for char in ["A-", "K-", "B-", "Q-", "M-"]:
-            case.pop(char + self.name)
-
-        new_lookup = []
-        if self.x_max > 10:
-            for i in range(int(self.x_min), int(self.x_max + 1)):
-                new_lookup.append(
-                    (
-                        i,
-                        max(
-                            min(self._gen_log(i, A, K, B, Q, M), self.y_max), self.y_min
-                        ),
-                    )
-                )
-        else:
-            for i in range(
-                int(self.x_min * 10), int(self.x_max * 10 + 1), max(int(self.x_max), 1)
-            ):
-                new_lookup.append(
-                    (
-                        i / 10,
-                        max(
-                            min(self._gen_log(i / 10, A, K, B, Q, M), self.y_max),
-                            self.y_min,
-                        ),
-                    )
-                )
-        return new_lookup
-
-    def _cat(self, case):
-        return self.values[case.pop("c-" + self.name)]
 
 
 def create_model_for_debugging(path_to_existing_model, path_to_new_model, error):

--- a/ema_workbench/connectors/vensim.py
+++ b/ema_workbench/connectors/vensim.py
@@ -7,18 +7,15 @@ used functions with error checking. For more fine grained control, the
 
 """
 
-import decimal
-import math
 import os
 
 import numpy as np
 
 from ..em_framework import FileModel, TimeSeriesOutcome
 from ..em_framework.model import SingleReplication
-from ..em_framework.parameters import CategoricalParameter, Parameter, RealParameter
 from ..em_framework.points import Experiment, Policy
-from ..em_framework.util import NamedObjectMap, Variable
-from ..util import CaseError, EMAError, EMAWarning, get_module_logger
+from ..em_framework.util import Variable
+from ..util import CaseError, EMAWarning, get_module_logger
 from ..util.ema_logging import method_logger
 from . import vensimDLLwrapper
 from .vensimDLLwrapper import VensimError, VensimWarning, command, get_val

--- a/test/test_connectors/test_vensim.py
+++ b/test/test_connectors/test_vensim.py
@@ -1,14 +1,13 @@
-"""Created on Jul 17, 2014
+"""Unit tests for Vensim and vensimDLLwrapper."""
 
-.. codeauthor:: jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
-"""
+# Created on Jul 17, 2014
+# .. codeauthor:: jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
 
 import os
 import unittest
 
-from ema_workbench.connectors.vensim import LookupUncertainty, VensimModel, load_model
+from ema_workbench.connectors.vensim import VensimModel, load_model
 from ema_workbench.em_framework import (
-    CategoricalParameter,
     RealParameter,
     TimeSeriesOutcome,
     perform_experiments,
@@ -19,78 +18,6 @@ __test__ = True
 
 if os.name != "nt":
     __test__ = False
-
-
-class VensimExampleModel(VensimModel):
-    """example of the most simple case of doing EMA on
-    a Vensim model.
-
-    """
-
-    # note that this reference to the model should be relative
-    # this relative path will be combined with the workingDirectory
-    model_file = r"\model.vpm"
-
-    # specify outcomes
-    outcomes = [TimeSeriesOutcome("a")]
-
-    # specify your uncertainties
-    uncertainties = [RealParameter("x11", 0, 2.5), RealParameter("x12", -2.5, 2.5)]
-
-
-class LookupTestModel(VensimModel):
-    def __init__(self, working_directory, name):
-        self.model_file = r"\lookup_model.vpm"
-        super().__init__(working_directory, name)
-
-        # vensim.load_model(self.modelFile)
-        self.outcomes = [TimeSeriesOutcome("flow1")]
-
-        """
-        each lookup uncertainty defined and added to the uncertainties list must be deleted immediately. it is not possible to do that in the constructor of lookups.
-        or i can delete it later before generating the cases.
-        """
-        self.uncertainties.append(
-            LookupUncertainty(
-                "hearne2",
-                [(0, 0.5), (-0.5, 0), (0, 0.75), (0.75, 1.5), (0.8, 1.2), (0.8, 1.2)],
-                "TF",
-                self,
-                0,
-                2,
-            )
-        )
-        # self.uncertainties.pop()
-        self.uncertainties.append(
-            LookupUncertainty(
-                "approximation",
-                [(0, 4), (1, 5), (1, 5), (0, 2), (0, 2)],
-                "TF2",
-                self,
-                0,
-                10,
-            )
-        )
-        # self.uncertainties.pop()
-        # self.uncertainties.append(ParameterUncertainty((0.02, 0.08), "rate1"))
-        # self.uncertainties.append(ParameterUncertainty((0.02, 0.08), "rate2"))
-        self.uncertainties.append(
-            LookupUncertainty(
-                "categories",
-                [
-                    [(0.0, 0.05), (0.25, 0.15), (0.5, 0.4), (0.75, 1), (1, 1.25)],
-                    [(0.0, 0.1), (0.25, 0.25), (0.5, 0.75), (1, 1.25)],
-                    [(0.0, 0.0), (0.1, 0.2), (0.3, 0.6), (0.6, 0.9), (1, 1.25)],
-                ],
-                "TF3",
-                self,
-                0,
-                2,
-            )
-        )
-        # self.uncertainties.pop()
-        self._delete_lookup_uncertainties()
-
 
 class VensimTest(unittest.TestCase):
     def test_be_quiet(self):
@@ -116,8 +43,14 @@ class VensimTest(unittest.TestCase):
 class VensimMSITest(unittest.TestCase):
     def test_vensim_model(self):
         # instantiate a model
-        wd = r"../models"
-        model = VensimExampleModel(wd, "simpleModel")
+        model = VensimModel("simple_model", wd="../models", model_file="model.vpm")
+        # specify outcomes
+        model.outcomes = [TimeSeriesOutcome("a")]
+
+        # specify your uncertainties
+        model.uncertainties = [RealParameter("x11", 0, 2.5),
+                               RealParameter("x12", -2.5, 2.5)]
+
 
         nr_runs = 10
         experiments, outcomes = perform_experiments(model, nr_runs)
@@ -125,88 +58,6 @@ class VensimMSITest(unittest.TestCase):
         self.assertEqual(experiments.shape[0], nr_runs)
         self.assertIn("TIME", outcomes.keys())
         self.assertIn(model.outcomes[0].name, outcomes.keys())
-
-
-class LookupUncertaintyTest(unittest.TestCase):
-    def test_added_uncertainties(self):
-        """The lookup uncertainty replaces itself with a set of other
-        uncertainties. Here we test whether this works correctly for
-        each of the options provided by the lookup uncertainty
-
-
-        """
-        if os.name != "nt":
-            return
-
-        # categories
-        msi = VensimModel("", "test")
-
-        lookup_type = "categories"
-        name = "test"
-        values = [
-            [(0.0, 0.05), (0.25, 0.15), (0.5, 0.4), (0.75, 1), (1, 1.25)],
-            [(0.0, 0.1), (0.25, 0.25), (0.5, 0.75), (1, 1.25)],
-            [(0.0, 0.0), (0.1, 0.2), (0.3, 0.6), (0.6, 0.9), (1, 1.25)],
-        ]
-        LookupUncertainty(lookup_type, values, name, msi)
-
-        self.assertEqual(len(msi.uncertainties), 1)
-        self.assertTrue(isinstance(msi.uncertainties[0], CategoricalParameter))
-
-        # hearne1
-        msi = VensimModel("", "test")
-        msi.uncertainties = []
-
-        lookup_type = "hearne1"
-        name = "test"
-        values = [(0, 1), (0, 1), (0, 1), (0, 1)]
-        LookupUncertainty(lookup_type, values, name, msi)
-
-        self.assertEqual(len(msi.uncertainties), 4)
-        for unc in msi.uncertainties:
-            self.assertTrue(isinstance(unc, RealParameter))
-
-        # hearne2
-        msi = VensimModel("", "test")
-        msi.uncertainties = []
-
-        lookup_type = "hearne2"
-        name = "test"
-        values = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (0, 1)]
-        LookupUncertainty(lookup_type, values, name, msi)
-
-        self.assertEqual(len(msi.uncertainties), 6)
-        for unc in msi.uncertainties:
-            self.assertTrue(isinstance(unc, RealParameter))
-
-        # approximation
-        msi = VensimModel("", "test")
-        msi.uncertainties = []
-
-        lookup_type = "approximation"
-        name = "test"
-        values = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (0, 1)]
-        LookupUncertainty(lookup_type, values, name, msi)
-
-        self.assertEqual(len(msi.uncertainties), 5)
-        for unc in msi.uncertainties:
-            self.assertTrue(isinstance(unc, RealParameter))
-
-    def test_running_lookup_uncertainties(self):
-        """This is the more comprehensive test, given that the lookup
-        uncertainty replaces itself with a bunch of other uncertainties, check
-        whether we can successfully run a set of experiments and get results
-        back. We assert that the uncertainties are correctly replaced by
-        analyzing the experiments array.
-
-        """
-        if os.name != "nt":
-            return
-
-        model = LookupTestModel(r"../models/", "lookupTestModel")
-
-        # model.step = 4 #reduce data to be stored
-        perform_experiments(model, 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This removes the lookup uncertainty class from vensim.py.

The feature was not well tested, might not even work at the moment anyway, and was not used

