### PR TITLE
Evaluator overhaul

### DIFF
--- a/ema_workbench/em_framework/evaluators.py
+++ b/ema_workbench/em_framework/evaluators.py
@@ -137,7 +137,7 @@ class BaseEvaluator(abc.ABC):
 
         searchover = problem.searchover
 
-        jobs_collection, scenarios, policies = None * 3
+        jobs_collection, scenarios, policies = (None,) * 3
         match searchover:
             case 'levers':
                 scenarios, policies = process_levers(jobs)

--- a/ema_workbench/em_framework/evaluators.py
+++ b/ema_workbench/em_framework/evaluators.py
@@ -392,7 +392,6 @@ def perform_experiments(
     nr_of_exp = -1
     match combine:
         case "factorial":
-
             nr_of_exp = n_models * n_scenarios * n_policies
 
             # TODO:: change to 0 policies / 0 scenarios is sampling set to 0 for

--- a/ema_workbench/em_framework/evaluators.py
+++ b/ema_workbench/em_framework/evaluators.py
@@ -33,7 +33,7 @@ from .samplers import (
     sample_levers,
     sample_uncertainties,
 )
-from .util import NamedObjectMap, determine_objects
+from .util import determine_objects
 
 # Created on 5 Mar 2017
 #
@@ -378,6 +378,7 @@ def perform_experiments(
         n_models = len(models)
     except TypeError:
         n_models = 1
+        models = [models,]
 
     outcomes = determine_objects(models, "outcomes", union=outcome_union)
 

--- a/ema_workbench/em_framework/evaluators.py
+++ b/ema_workbench/em_framework/evaluators.py
@@ -309,7 +309,7 @@ def perform_experiments(
     lever_sampling_kwargs:dict|None=None,
     callback:Callable|None=None,
     return_callback:bool=False,
-    combine="factorial",
+    combine:str="factorial",
     log_progress:bool=False,
     **kwargs,
 ):
@@ -413,7 +413,7 @@ def perform_experiments(
     if not evaluator:
         evaluator = SequentialEvaluator(models)
 
-    experiments = experiment_generator(scenarios, policies, callback, combine=combine)
+    experiments = experiment_generator(models, scenarios, policies, combine=combine)
 
     evaluator.evaluate_experiments(experiments, callback,**kwargs)
 

--- a/ema_workbench/em_framework/evaluators.py
+++ b/ema_workbench/em_framework/evaluators.py
@@ -4,6 +4,7 @@ import enum
 import numbers
 import os
 from collections.abc import Callable, Iterable
+from typing import Literal
 
 from platypus import Algorithm
 
@@ -67,6 +68,8 @@ class Samplers(enum.Enum):
     FAST = FASTSampler()
     MORRIS = MorrisSampler()
 
+
+SamplerTypes = Literal[Samplers.MC, Samplers.LHS, Samplers.FF, Samplers.SOBOL, Samplers.FAST, Samplers.MORRIS]
 
 class BaseEvaluator(abc.ABC):
     """evaluator for experiments using a multiprocessing pool.
@@ -180,9 +183,9 @@ class BaseEvaluator(abc.ABC):
             uncertainty_union: bool = False,
             lever_union: bool = False,
             outcome_union: bool = False,
-            uncertainty_sampling: AbstractSampler = Samplers.LHS,
+            uncertainty_sampling: AbstractSampler|SamplerTypes = Samplers.LHS,
             uncertainty_sampling_kwargs: dict | None = None,
-            lever_sampling: AbstractSampler = Samplers.LHS,
+            lever_sampling: AbstractSampler|SamplerTypes = Samplers.LHS,
             lever_sampling_kwargs: dict | None = None,
             callback: type[AbstractCallback] | None = None,
             combine="factorial",
@@ -310,9 +313,9 @@ def perform_experiments(
     uncertainty_union:bool=False,
     lever_union:bool=False,
     outcome_union:bool=False,
-    uncertainty_sampling:AbstractSampler=Samplers.LHS,
+    uncertainty_sampling:AbstractSampler|SamplerTypes=Samplers.LHS,
     uncertainty_sampling_kwargs:dict|None=None,
-    lever_sampling:AbstractSampler=Samplers.LHS,
+    lever_sampling:AbstractSampler|SamplerTypes=Samplers.LHS,
     lever_sampling_kwargs:dict|None=None,
     callback:type[AbstractCallback]|None=None,
     return_callback:bool=False,
@@ -476,7 +479,7 @@ def setup_callback(
     return callback
 
 
-def setup_policies(policies:int|DesignIterator|Policy, sampler:AbstractSampler|None, lever_sampling_kwargs, models):
+def setup_policies(policies:int|DesignIterator|Policy, sampler:AbstractSampler|SamplerTypes|None, lever_sampling_kwargs, models):
     # todo fix sampler type hints by adding Literal[all fields of sampler enum]
 
     if not policies:
@@ -504,7 +507,7 @@ def setup_policies(policies:int|DesignIterator|Policy, sampler:AbstractSampler|N
     return policies, levers, n_policies
 
 
-def setup_scenarios(scenarios:int|DesignIterator|Scenario, sampler:AbstractSampler|None, uncertainty_sampling_kwargs, models):
+def setup_scenarios(scenarios:int|DesignIterator|Scenario, sampler:AbstractSampler|SamplerTypes|None, uncertainty_sampling_kwargs, models):
     # todo fix sampler type hints by adding Literal[all fields of sampler enum]
 
     if not scenarios:

--- a/ema_workbench/em_framework/experiment_runner.py
+++ b/ema_workbench/em_framework/experiment_runner.py
@@ -38,7 +38,7 @@ class ExperimentRunner:
 
     def __init__(self, msis):
         """Init."""
-        self.msis = msis
+        self.msis = msis.copy()
         self.log_message = (
             "running scenario {scenario_id} for policy "
             "{policy_name} on model {model_name}"

--- a/ema_workbench/em_framework/experiment_runner.py
+++ b/ema_workbench/em_framework/experiment_runner.py
@@ -4,6 +4,8 @@ from ema_workbench.util.ema_logging import method_logger
 
 from ..util import CaseError, EMAError, get_module_logger
 from .points import Point
+from .util import NamedObjectMap
+from .model import AbstractModel
 
 # Created on Aug 11, 2015
 #
@@ -38,7 +40,9 @@ class ExperimentRunner:
 
     def __init__(self, msis):
         """Init."""
-        self.msis = msis.copy()
+        self.msis = NamedObjectMap(AbstractModel)
+        self.msis.extend(msis)
+
         self.log_message = (
             "running scenario {scenario_id} for policy "
             "{policy_name} on model {model_name}"

--- a/ema_workbench/em_framework/futures_ipyparallel.py
+++ b/ema_workbench/em_framework/futures_ipyparallel.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import socket
 import threading
+from collections.abc import Callable, Iterable
 
 import zmq
 from ipyparallel.engine.log import EnginePUBHandler
@@ -18,9 +19,10 @@ from zmq.eventloop import zmqstream
 
 from ..util import ema_exceptions, ema_logging, get_module_logger
 from . import experiment_runner
-from .evaluators import BaseEvaluator, experiment_generator
+from .evaluators import BaseEvaluator
 from .futures_util import setup_working_directories
 from .model import AbstractModel
+from .points import Experiment
 from .util import NamedObjectMap
 
 # Created on Jul 16, 2015
@@ -381,14 +383,12 @@ class IpyparallelEvaluator(BaseEvaluator):
         cleanup(self.client)
 
     def evaluate_experiments(
-        self, scenarios, policies, callback, combine="factorial", **kwargs
+        self, experiments:Iterable[Experiment], callback:Callable, **kwargs
     ):
         """Evaluate experiments."""
-        ex_gen = experiment_generator(scenarios, self._msis, policies, combine=combine)
-
         lb_view = self.client.load_balanced_view()
         results = lb_view.map(
-            _run_experiment, ex_gen, ordered=False, block=False, **kwargs
+            _run_experiment, experiments, ordered=False, block=False, **kwargs
         )
 
         for entry in results:

--- a/ema_workbench/em_framework/futures_ipyparallel.py
+++ b/ema_workbench/em_framework/futures_ipyparallel.py
@@ -280,9 +280,7 @@ class Engine:
         _logger.debug(f"setting root working directory to {cwd}")
         os.chdir(cwd)
 
-        models = NamedObjectMap(AbstractModel)
-        models.extend(msis)
-        self.runner = experiment_runner.ExperimentRunner(models)
+        self.runner = experiment_runner.ExperimentRunner(msis)
 
         self.tmpdir = setup_working_directories(msis, os.getcwd())
 

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -47,9 +47,7 @@ def mpi_initializer(models, log_level, root_dir):
     rank = MPI.COMM_WORLD.Get_rank()
 
     # setup the experiment runner
-    msis = NamedObjectMap(AbstractModel)
-    msis.extend(models)
-    experiment_runner = ExperimentRunner(msis)
+    experiment_runner = ExperimentRunner(models)
 
     # setup the working directories
     tmpdir = setup_working_directories(models, root_dir)

--- a/ema_workbench/em_framework/futures_mpi.py
+++ b/ema_workbench/em_framework/futures_mpi.py
@@ -7,13 +7,15 @@ import shutil
 import threading
 import time
 import warnings
+from collections.abc import Callable, Iterable
 from logging.handlers import QueueHandler
 
 from ..util import get_module_logger, get_rootlogger, method_logger
-from .evaluators import BaseEvaluator, experiment_generator
+from .evaluators import BaseEvaluator
 from .experiment_runner import ExperimentRunner
 from .futures_util import determine_rootdir, finalizer, setup_working_directories
 from .model import AbstractModel
+from .points import Experiment
 from .util import NamedObjectMap
 
 __all__ = ["MPIEvaluator"]
@@ -222,12 +224,10 @@ class MPIEvaluator(BaseEvaluator):
 
     @method_logger(__name__)
     def evaluate_experiments(
-        self, scenarios, policies, callback, combine="factorial", **kwargs
+        self, experiments:Iterable[Experiment], callback:Callable, **kwargs
     ):
         """Evaluate experiments using MPIPoolExecutor."""
-        experiments = list(
-            experiment_generator(scenarios, self._msis, policies, combine=combine)
-        )
+        experiments = list(experiments)
 
         results = self._pool.map(run_experiment_mpi, experiments, **kwargs)
         for experiment, outcomes in results:

--- a/ema_workbench/em_framework/futures_multiprocessing.py
+++ b/ema_workbench/em_framework/futures_multiprocessing.py
@@ -9,13 +9,15 @@ import sys
 import threading
 import traceback
 import warnings
+from collections.abc import Callable, Iterable
 from logging import handlers
 
 from ..util import ema_logging, get_module_logger
-from .evaluators import BaseEvaluator, experiment_generator
+from .evaluators import BaseEvaluator
 from .experiment_runner import ExperimentRunner
 from .futures_util import determine_rootdir, finalizer, setup_working_directories
 from .model import AbstractModel
+from .points import Experiment
 from .util import NamedObjectMap
 
 # Created on 22 Feb 2017
@@ -321,7 +323,6 @@ class MultiprocessingEvaluator(BaseEvaluator):
         if self.root_dir:
             shutil.rmtree(self.root_dir)
 
-    def evaluate_experiments(self, scenarios, policies, callback, combine="factorial"):
+    def evaluate_experiments(self, experiments:Iterable[Experiment], callback:Callable, **kwargs):
         """Evaluate experiments."""
-        ex_gen = experiment_generator(scenarios, self._msis, policies, combine=combine)
-        add_tasks(self.n_processes, self._pool, ex_gen, callback)
+        add_tasks(self.n_processes, self._pool, experiments, callback)

--- a/ema_workbench/em_framework/futures_multiprocessing.py
+++ b/ema_workbench/em_framework/futures_multiprocessing.py
@@ -48,9 +48,7 @@ def initializer(*args):
     models, queue, log_level, root_dir = args
 
     # setup the experiment runner
-    msis = NamedObjectMap(AbstractModel)
-    msis.extend(models)
-    experiment_runner = ExperimentRunner(msis)
+    experiment_runner = ExperimentRunner(models)
 
     # setup the logging
     setup_logging(queue, log_level)

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -172,7 +172,7 @@ class RobustProblem(Problem):
         self.robustness_functions = robustness_functions
 
 
-def to_problem(model:AbstractModel, searchover:str, reference=None, constraints=None):
+def to_problem(model:AbstractModel, searchover:str, reference:Scenario|Policy|None=None, constraints=None):
     """Helper function to create Problem object.
 
     Parameters
@@ -1126,8 +1126,6 @@ def _optimize(
     )
     callback = functools.partial(convergence, optimizer)
     evaluator.callback = callback
-
-
 
     with temporary_filter(name=[callbacks.__name__, evaluators.__name__], level=INFO):
         optimizer.run(nfe)

--- a/ema_workbench/em_framework/optimization.py
+++ b/ema_workbench/em_framework/optimization.py
@@ -1127,6 +1127,8 @@ def _optimize(
     callback = functools.partial(convergence, optimizer)
     evaluator.callback = callback
 
+
+
     with temporary_filter(name=[callbacks.__name__, evaluators.__name__], level=INFO):
         optimizer.run(nfe)
 

--- a/ema_workbench/em_framework/points.py
+++ b/ema_workbench/em_framework/points.py
@@ -234,7 +234,7 @@ def combine_cases_factorial(*point_collections):
 #     return combined_cases
 
 
-def experiment_generator(scenarios:Iterable[Scenario], models:Iterable["AbstractModel"], policies:Iterable[Policy], combine:str="factorial"):
+def experiment_generator(models:Iterable["AbstractModel"], scenarios:Iterable[Scenario], policies:Iterable[Policy], combine:str="factorial"):
     """Generator function which yields experiments.
 
     Parameters

--- a/ema_workbench/em_framework/points.py
+++ b/ema_workbench/em_framework/points.py
@@ -7,6 +7,7 @@ As well as associated helper functions
 import itertools
 import random
 from collections import ChainMap
+from collections.abc import Iterable
 
 from ema_workbench.em_framework.util import Counter, NamedDict, NamedObject, combine
 from ema_workbench.util import get_module_logger
@@ -104,7 +105,7 @@ class Experiment(NamedObject):
 
     """
 
-    def __init__(self, name, model_name, policy, scenario, experiment_id):
+    def  __init__(self, name, model_name, policy, scenario, experiment_id):
         super().__init__(name)
         self.experiment_id = experiment_id
         self.policy = policy
@@ -233,7 +234,7 @@ def combine_cases_factorial(*point_collections):
 #     return combined_cases
 
 
-def experiment_generator(scenarios, models, policies, combine="factorial"):
+def experiment_generator(scenarios:Iterable[Scenario], models:Iterable["AbstractModel"], policies:Iterable[Policy], combine:str="factorial"):
     """Generator function which yields experiments.
 
     Parameters
@@ -259,7 +260,7 @@ def experiment_generator(scenarios, models, policies, combine="factorial"):
     """
     # TODO combine_ functions can be made more generic
     # basically combine any collection
-    # wrap around to yield specific type of class (e.g. point
+    # wrap around to yield specific type of class (e.g. point)
 
     if combine == "sample":
         jobs = zip_cycle(models, policies, scenarios)

--- a/ema_workbench/em_framework/points.py
+++ b/ema_workbench/em_framework/points.py
@@ -157,7 +157,7 @@ def zip_cycle(*args):
     #     policies and scenarios are generators themselves?
     # TODO to be replaced with sample based combining
 
-    max_len = max(len(a) for a in args)
+    max_len = max(len(list(a)) for a in args)
     return itertools.islice(zip(*(itertools.cycle(a) for a in args)), max_len)
 
 

--- a/ema_workbench/em_framework/samplers.py
+++ b/ema_workbench/em_framework/samplers.py
@@ -9,7 +9,7 @@ Monte Carlo sampling.
 import abc
 import itertools
 import numbers
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 
 import numpy as np
 import scipy.stats as stats
@@ -42,6 +42,9 @@ __all__ = [
 ]
 
 
+SeedLike = int | np.integer | Sequence[int] | np.random.SeedSequence
+RNGLike = np.random.Generator | np.random.BitGenerator
+
 class AbstractSampler(metaclass=abc.ABCMeta):
     """Abstract base class from which different samplers can be derived.
 
@@ -52,7 +55,7 @@ class AbstractSampler(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def generate_samples(self, parameters:list[Parameter], size:int, rng:np.random.Generator|None = None, **kwargs) -> np.ndarray:
+    def generate_samples(self, parameters:list[Parameter], size:int, rng:SeedLike|RNGLike|None = None, **kwargs) -> np.ndarray:
         """Generate n samples from the parameters.
 
         Parameters
@@ -89,7 +92,7 @@ class AbstractSampler(metaclass=abc.ABCMeta):
 class LHSSampler(AbstractSampler):
     """generates a Latin Hypercube sample over the parameters."""
 
-    def generate_samples(self, parameters:list[Parameter], size:int, rng:np.random.Generator|None = None, **kwargs) -> np.ndarray:
+    def generate_samples(self, parameters:list[Parameter], size:int, rng:SeedLike|RNGLike|None = None, **kwargs) -> np.ndarray:
         """Generate samples using latin hypercube sampling.
 
         Parameters
@@ -125,7 +128,7 @@ class LHSSampler(AbstractSampler):
 class MonteCarloSampler(AbstractSampler):
     """Monte Carlo sampler for each of the parameters."""
 
-    def generate_samples(self, parameters:list[Parameter], size:int, rng:np.random.Generator|None = None, **kwargs) -> np.ndarray:
+    def generate_samples(self, parameters:list[Parameter], size:int, rng:SeedLike|RNGLike|None = None, **kwargs) -> np.ndarray:
         """Generate samples using Monte Carlo sampling.
 
         Parameters
@@ -157,7 +160,7 @@ class FullFactorialSampler(AbstractSampler):
 
     """
 
-    def generate_samples(self, parameters:list[Parameter], size:int, rng:np.random.Generator|None = None, **kwargs) -> np.ndarray:
+    def generate_samples(self, parameters:list[Parameter], size:int, rng:SeedLike|RNGLike|None = None, **kwargs) -> np.ndarray:
         """Generate samples using full factorial sampling.
 
         Parameters
@@ -211,7 +214,7 @@ def determine_parameters(models, attribute, union=True):
     return util.determine_objects(models, attribute, union=union)
 
 
-def sample_parameters(parameters:list[Parameter], n_samples: numbers.Integral, sampler:AbstractSampler|None=None, kind=Point, **kwargs):
+def sample_parameters(parameters:list[Parameter], n_samples: int, sampler:AbstractSampler|None=None, kind=Point, **kwargs):
     """Generate cases by sampling over the parameters.
 
     Parameters
@@ -235,7 +238,7 @@ def sample_parameters(parameters:list[Parameter], n_samples: numbers.Integral, s
     return DesignIterator(samples, parameters, kind)
 
 
-def sample_levers(models, n_samples:numbers.Integral, sampler:AbstractSampler|None=None, **kwargs):
+def sample_levers(models, n_samples:int, sampler:AbstractSampler|None=None, **kwargs):
     """Generate policies by sampling over the levers.
 
     Parameters

--- a/ema_workbench/examples/example_lake_model.py
+++ b/ema_workbench/examples/example_lake_model.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
 
     # specify outcomes
     lake_model.outcomes = [
-        ScalarOutcome("max_P"),
+        ScalarOutcome("max_p"),
         ScalarOutcome("utility"),
         ScalarOutcome("inertia"),
         ScalarOutcome("reliability"),

--- a/ema_workbench/examples/example_lake_model.py
+++ b/ema_workbench/examples/example_lake_model.py
@@ -56,5 +56,7 @@ if __name__ == "__main__":
 
     with MultiprocessingEvaluator(lake_model) as evaluator:
         res = evaluator.perform_experiments(
-            n_scenarios, n_policies, lever_sampling=Samplers.MC
+            n_scenarios, n_policies, lever_sampling=Samplers.MC,
+            lever_sampling_kwargs={"rng":42},
+            uncertainty_sampling_kwargs={"rng":42},
         )

--- a/ema_workbench/examples/lake_models.py
+++ b/ema_workbench/examples/lake_models.py
@@ -18,6 +18,7 @@ def lake_problem_intertemporal(
     delta=0.98,  # standard deviation of natural inflows
     alpha=0.4,  # utility from pollution
     nsamples=100,  # Monte Carlo sampling of natural inflows
+    rng = 42,
     **kwargs,
 ):
     """Run the intertemporal version of the shallow lake model."""
@@ -27,6 +28,8 @@ def lake_problem_intertemporal(
         decisions = [0] * 100
         print("No valid decisions found, using 0 pollution release per year as default")
 
+    rng = np.random.default_rng(rng)
+
     nvars = len(decisions)
     decisions = np.array(decisions)
 
@@ -34,7 +37,7 @@ def lake_problem_intertemporal(
     p_crit = brentq(lambda x: x**q / (1 + x**q) - b * x, 0.01, 1.5)
 
     # Generate natural inflows using lognormal distribution
-    natural_inflows = np.random.lognormal(
+    natural_inflows = rng.lognormal(
         mean=math.log(mean**2 / math.sqrt(stdev**2 + mean**2)),
         sigma=math.sqrt(math.log(1.0 + stdev**2 / mean**2)),
         size=(nsamples, nvars),
@@ -112,9 +115,12 @@ def lake_problem_dps(
     r1=0.5,
     r2=0.5,
     w1=0.5,
+    rng=42,
 ):
     """DPS version of the lake problem."""
     p_crit = brentq(lambda x: x**q / (1 + x**q) - b * x, 0.01, 1.5)
+
+    rng = np.random.default_rng(rng)
 
     X = np.zeros(myears) # noqa: N806
     average_daily_p = np.zeros(myears)
@@ -129,7 +135,7 @@ def lake_problem_dps(
         decisions = np.zeros(myears)
         decisions[0] = decision
 
-        natural_inflows = np.random.lognormal(
+        natural_inflows = rng.lognormal(
             math.log(mean**2 / math.sqrt(stdev**2 + mean**2)),
             math.sqrt(math.log(1.0 + stdev**2 / mean**2)),
             size=myears,

--- a/ema_workbench/examples/optimization_lake_model_intertemporal.py
+++ b/ema_workbench/examples/optimization_lake_model_intertemporal.py
@@ -59,6 +59,7 @@ if __name__ == "__main__":
         )
     ]
 
+
     with MultiprocessingEvaluator(lake_model) as evaluator:
         results, convergence = evaluator.optimize(
             nfe=5000,
@@ -66,4 +67,5 @@ if __name__ == "__main__":
             epsilons=[0.125, 0.05, 0.01, 0.01],
             convergence=convergence_metrics,
             constraints=constraints,
+            rng=42
         )

--- a/test/test_em_framework/test_evaluators.py
+++ b/test/test_em_framework/test_evaluators.py
@@ -89,7 +89,22 @@ def test_perform_experiments(mocker):
         evaluators.perform_experiments(model, n_scenarios, n_policies, combine="wrong value" )
 
 def test_optimize(mocker):
-    pass
+    mocked_function = mocker.Mock(return_value={"d":1, "e":1})
+    model = ema_workbench.Model("test", function=mocked_function)
+    model.uncertainties = [RealParameter("a", 0,1)]
+    model.levers = [RealParameter("b", 0,1),
+                    RealParameter("c", 0,1)]
+    model.outcomes = [ScalarOutcome("d", kind=ScalarOutcome.MAXIMIZE),
+                      ScalarOutcome("e", kind=ScalarOutcome.MAXIMIZE)]
+
+    nfe = 100
+
+    with  evaluators.SequentialEvaluator(model) as evaluator:
+        evaluator.optimize(nfe=nfe, searchover='levers', epsilons=[0.1, 0.1])
+
+    # fixme what to mock
+    # fixme what to assert
+
 
 def test_robust_optimize(mocker):
     pass

--- a/test/test_em_framework/test_evaluators.py
+++ b/test/test_em_framework/test_evaluators.py
@@ -3,9 +3,11 @@
 import pytest
 
 import ema_workbench
+from ema_workbench import RealParameter, ScalarOutcome
 from ema_workbench.em_framework import evaluators
 from ema_workbench.em_framework.points import Experiment, Policy, Scenario
 from ema_workbench.em_framework.experiment_runner import ExperimentRunner
+from ema_workbench import EMAError
 
 # Created on 14 Mar 2017
 #
@@ -25,15 +27,47 @@ def test_sequential_evalutor(mocker):
 
     mocked_callback = mocker.patch("ema_workbench.em_framework.evaluators.DefaultCallback")
 
-    evaluator = evaluators.SequentialEvaluator(model)
-    evaluator.evaluate_experiments(mocked_generator([], [], []), mocked_callback)
+    with  evaluators.SequentialEvaluator(model) as evaluator:
+        evaluator.evaluate_experiments(mocked_generator([], [], []), mocked_callback)
 
     for i, entry in enumerate(mocked_runner.run_experiment.call_args_list):
         assert entry.args[0].name == str(i)
 
+    with pytest.raises(TypeError):
+        evaluators.SequentialEvaluator([object()])
 
-    def test_perform_experiments(self):
-        pass
 
+def test_perform_experiments(mocker):
+    mocked_function = mocker.Mock(return_value={"c":1})
+    model = ema_workbench.Model("test", function=mocked_function)
+    model.uncertainties = [RealParameter("a", 0,1)]
+    model.levers = [RealParameter("b", 0,1)]
+    model.outcomes = [ScalarOutcome("c")]
+
+    n_experiments = 10
+
+    mocked_callback = mocker.patch("ema_workbench.em_framework.evaluators.DefaultCallback")
+    mocked_callback.return_value.i = n_experiments
+
+    with  evaluators.SequentialEvaluator(model) as evaluator:
+        evaluator.perform_experiments(10, 1,)
+
+    # what to check?
+
+    evaluators.perform_experiments(model,10, 1,)
+
+    mocked_callback.return_value.i = 1
+    with pytest.raises(EMAError):
+        evaluators.perform_experiments(model, 10, 1, )
+
+    with pytest.raises(EMAError):
+        evaluators.perform_experiments(model )
+
+
+def test_optimize(mocker):
+    pass
+
+def test_robust_optimize(mocker):
+    pass
 
 

--- a/test/test_em_framework/test_evaluators.py
+++ b/test/test_em_framework/test_evaluators.py
@@ -99,11 +99,25 @@ def test_optimize(mocker):
 
     nfe = 100
 
+    mocked_optimize = mocker.patch("ema_workbench.em_framework.evaluators._optimize", autospec=True)
     with  evaluators.SequentialEvaluator(model) as evaluator:
         evaluator.optimize(nfe=nfe, searchover='levers', epsilons=[0.1, 0.1])
+    assert mocked_optimize.call_count == 1
 
-    # fixme what to mock
-    # fixme what to assert
+    mocked_optimize.reset_mock()
+    with  evaluators.SequentialEvaluator(model) as evaluator:
+        evaluator.optimize(nfe=nfe, searchover='uncertainties', epsilons=[0.1, 0.1])
+    assert mocked_optimize.call_count == 1
+
+    mocked_optimize.reset_mock()
+    evaluators.optimize(model, nfe=nfe, searchover='uncertainties', epsilons=[0.1, 0.1])
+    assert mocked_optimize.call_count == 1
+
+
+    with pytest.raises(NotImplementedError):
+        evaluators.optimize([model, model], nfe=nfe, searchover='uncertainties', epsilons=[0.1, 0.1])
+    with pytest.raises(EMAError):
+        evaluators.optimize([model, model], nfe=nfe, searchover='unknown value', epsilons=[0.1, 0.1])
 
 
 def test_robust_optimize(mocker):

--- a/test/test_em_framework/test_evaluators.py
+++ b/test/test_em_framework/test_evaluators.py
@@ -121,6 +121,24 @@ def test_optimize(mocker):
 
 
 def test_robust_optimize(mocker):
-    pass
+    mocked_function = mocker.Mock(return_value={"d":1, "e":1})
+    model = ema_workbench.Model("test", function=mocked_function)
+    model.uncertainties = [RealParameter("a", 0,1)]
+    model.levers = [RealParameter("b", 0,1),
+                    RealParameter("c", 0,1)]
+    model.outcomes = [ScalarOutcome("d", kind=ScalarOutcome.MAXIMIZE),
+                      ScalarOutcome("e", kind=ScalarOutcome.MAXIMIZE)]
+
+
+    robustness_functions = [ScalarOutcome("robustness_d", kind=ScalarOutcome.MAXIMIZE, variable_name="d", function=mocker.Mock(return_value={"r_d":0.5})),
+                            ScalarOutcome("robustness_e", kind=ScalarOutcome.MAXIMIZE, variable_name="e", function=mocker.Mock(return_value={"r_e":0.5})),]
+    scenarios = 10
+
+    nfe = 100
+
+    mocked_optimize = mocker.patch("ema_workbench.em_framework.evaluators._optimize", autospec=True)
+    with  evaluators.SequentialEvaluator(model) as evaluator:
+        evaluator.robust_optimize(robustness_functions, scenarios=scenarios, nfe=nfe, epsilons=[0.1, 0.1])
+    assert mocked_optimize.call_count == 1
 
 

--- a/test/test_em_framework/test_evaluators.py
+++ b/test/test_em_framework/test_evaluators.py
@@ -115,9 +115,11 @@ def test_optimize(mocker):
 
 
     with pytest.raises(NotImplementedError):
-        evaluators.optimize([model, model], nfe=nfe, searchover='uncertainties', epsilons=[0.1, 0.1])
+        with  evaluators.SequentialEvaluator([model, model]) as evaluator:
+            evaluator.optimize(nfe=nfe, searchover='uncertainties', epsilons=[0.1, 0.1])
     with pytest.raises(EMAError):
-        evaluators.optimize([model, model], nfe=nfe, searchover='unknown value', epsilons=[0.1, 0.1])
+        with  evaluators.SequentialEvaluator(model) as evaluator:
+            evaluator.optimize(nfe=nfe, searchover='unknown value', epsilons=[0.1, 0.1])
 
 
 def test_robust_optimize(mocker):

--- a/test/test_em_framework/test_evaluators.py
+++ b/test/test_em_framework/test_evaluators.py
@@ -44,25 +44,49 @@ def test_perform_experiments(mocker):
     model.levers = [RealParameter("b", 0,1)]
     model.outcomes = [ScalarOutcome("c")]
 
-    n_experiments = 10
+    n_scenarios = 10
+    n_policies = 2
+    n_experiments = n_scenarios * n_policies
 
-    mocked_callback = mocker.patch("ema_workbench.em_framework.evaluators.DefaultCallback")
-    mocked_callback.return_value.i = n_experiments
+    mocked_callback_class = mocker.patch("ema_workbench.em_framework.evaluators.DefaultCallback")
+    mocked_callback_instance = mocker.Mock()
+    mocked_callback_class.return_value = mocked_callback_instance
+    mocked_callback_instance.i = n_experiments # this is an implicit assert
 
     with  evaluators.SequentialEvaluator(model) as evaluator:
-        evaluator.perform_experiments(10, 1,)
+        evaluator.perform_experiments(n_scenarios, n_policies,)
+
+
+    mocked_callback_class = mocker.patch("ema_workbench.em_framework.evaluators.DefaultCallback")
+    mocked_callback_instance = mocker.Mock()
+    mocked_callback_class.return_value = mocked_callback_instance
+    mocked_callback_instance.i = n_scenarios # this is an implicit assert
+
+    with  evaluators.SequentialEvaluator(model) as evaluator:
+        evaluator.perform_experiments(n_scenarios, n_policies, combine="sample")
 
     # what to check?
+    # fixme, all kinds of permutations of all the possible keyword arguments
 
-    evaluators.perform_experiments(model,10, 1,)
+    mocked_callback_class = mocker.patch("ema_workbench.em_framework.evaluators.DefaultCallback")
+    mocked_callback_instance = mocker.Mock()
+    mocked_callback_class.return_value = mocked_callback_instance
+    mocked_callback_instance.i = n_experiments
+    ret = evaluators.perform_experiments(model,n_scenarios, n_policies, return_callback=True, callback=mocked_callback_class)
+    assert ret == mocked_callback_instance
 
-    mocked_callback.return_value.i = 1
+    mocked_callback_class = mocker.patch("ema_workbench.em_framework.evaluators.DefaultCallback")
+    mocked_callback_instance = mocker.Mock()
+    mocked_callback_class.return_value = mocked_callback_instance
+    mocked_callback_instance.i = 1
     with pytest.raises(EMAError):
-        evaluators.perform_experiments(model, 10, 1, )
+        evaluators.perform_experiments(model, n_scenarios, n_policies, )
 
     with pytest.raises(EMAError):
         evaluators.perform_experiments(model )
 
+    with pytest.raises(ValueError):
+        evaluators.perform_experiments(model, n_scenarios, n_policies, combine="wrong value" )
 
 def test_optimize(mocker):
     pass

--- a/test/test_em_framework/test_experiment_runner.py
+++ b/test/test_em_framework/test_experiment_runner.py
@@ -20,11 +20,9 @@ class ExperimentRunnerTestCase(unittest.TestCase):
     def test_init(self):
         mockMSI = mock.Mock(spec=Model)
         mockMSI.name = "test"
-        msis = {"test": mockMSI}
+        runner = ExperimentRunner( [mockMSI])
 
-        runner = ExperimentRunner(msis)
-
-        self.assertEqual(msis, runner.msis)
+        self.assertEqual(mockMSI, runner.msis[mockMSI.name])
 
     def test_run_experiment(self):
         mock_msi = mock.Mock(spec=Model)
@@ -32,10 +30,7 @@ class ExperimentRunnerTestCase(unittest.TestCase):
         mock_msi.uncertainties = [RealParameter("a", 0, 10), RealParameter("b", 0, 10)]
         mock_msi.constants = []
 
-        msis = NamedObjectMap(AbstractModel)
-        msis["test"] = mock_msi
-
-        runner = ExperimentRunner(msis)
+        runner = ExperimentRunner([mock_msi])
 
         experiment = Experiment(
             "test", mock_msi.name, Policy("none"), Scenario(a=1, b=2), 0

--- a/test/test_em_framework/test_futures_ipyparallel.py
+++ b/test/test_em_framework/test_futures_ipyparallel.py
@@ -1,8 +1,13 @@
-"""Created on Jul 28, 2015
-test code for ema_ipyparallel. The setup and teardown of the cluster is
+"""Tests for ipyparallelEvaluator.
+
+Test code for ema_ipyparallel. The setup and teardown of the cluster is
 taken from the ipyparallel test code with some minor adaptations
-.. codeauthor:: jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
+
+
 """
+
+# Created on Jul 28, 2015
+# .. codeauthor:: jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
 
 import logging
 import os
@@ -38,7 +43,7 @@ warnings.filterwarnings("ignore", category=DeprecationWarning, module=".*/IPytho
 
 # Launcher class
 class MockProcessLauncher(LocalProcessLauncher):
-    """subclass LocalProcessLauncher, to prevent extra sockets and threads being created on Windows"""
+    """subclass LocalProcessLauncher, to prevent extra sockets and threads being created on Windows."""
 
     def start(self):
         if self.state == "before":
@@ -419,10 +424,8 @@ class TestIpyParallelEvaluator(unittest.TestCase):
     @mock.patch("ema_workbench.em_framework.futures_ipyparallel.initialize_engines")
     @mock.patch("ema_workbench.em_framework.futures_ipyparallel.start_logwatcher")
     @mock.patch("ema_workbench.em_framework.evaluators.DefaultCallback")
-    @mock.patch("ema_workbench.em_framework.futures_ipyparallel.experiment_generator")
     def test_ipyparallel_evaluator(
         self,
-        mocked_generator,
         mocked_callback,
         mocked_start,
         mocked_initialize,
@@ -430,6 +433,8 @@ class TestIpyParallelEvaluator(unittest.TestCase):
     ):
         model = mock.Mock(spec=ema_workbench.Model)
         model.name = "test"
+
+        mocked_generator = mock.Mock("ema_workbench.em_framework.points.experiment_generator")
         mocked_generator.return_value = [1]
         mocked_start.return_value = mocked_start, None
 
@@ -440,7 +445,7 @@ class TestIpyParallelEvaluator(unittest.TestCase):
         client.load_balanced_view.return_value = lb_view
 
         with ema.IpyparallelEvaluator(model, client) as evaluator:
-            evaluator.evaluate_experiments(10, 10, mocked_callback)
+            evaluator.evaluate_experiments(mocked_generator, mocked_callback)
             lb_view.map.assert_called_once()
 
 

--- a/test/test_em_framework/test_futures_mpi.py
+++ b/test/test_em_framework/test_futures_mpi.py
@@ -46,9 +46,9 @@ def test_mpi_evaluator(mocker):
         "ema_workbench.em_framework.evaluators.DefaultCallback",
     )
     mocked_generator = mocker.patch(
-        "ema_workbench.em_framework.futures_mpi.experiment_generator",
-        autospec=True,
+        "ema_workbench.em_framework.points.experiment_generator", autospec=True
     )
+    mocked_generator.return_value = iter([1,])
 
 
     model = Mock(spec=ema_workbench.Model)
@@ -67,7 +67,7 @@ def test_mpi_evaluator(mocker):
     mocked_MPIPoolExecutor.return_value = pool_mock
 
     with futures_mpi.MPIEvaluator(model) as evaluator:
-        evaluator.evaluate_experiments(10, 10, mocked_callback)
+        evaluator.evaluate_experiments(mocked_generator([], [], []), mocked_callback)
 
         mocked_MPIPoolExecutor.assert_called()
         pool_mock.map.assert_called_once()
@@ -124,8 +124,7 @@ def test_mpi_initializer(mocker):
     mocked_MPI = mocker.patch("mpi4py.MPI", autospec=True) # noqa: N806
 
     mocker.patch(
-        "ema_workbench.em_framework.futures_mpi.experiment_generator",
-        autospec=True,
+        "ema_workbench.em_framework.points.experiment_generator", autospec=True
     )
 
     mocked_MPI.COMM_WORLD = Mock()

--- a/test/test_em_framework/test_futures_multiprocessing.py
+++ b/test/test_em_framework/test_futures_multiprocessing.py
@@ -16,19 +16,17 @@ __all__ = []
 class TestEvaluators(unittest.TestCase):
     @mock.patch("ema_workbench.em_framework.futures_multiprocessing.multiprocessing")
     @mock.patch("ema_workbench.em_framework.evaluators.DefaultCallback")
-    @mock.patch(
-        "ema_workbench.em_framework.futures_multiprocessing.experiment_generator"
-    )
     @mock.patch("ema_workbench.em_framework.futures_multiprocessing.add_tasks")
     def test_multiprocessing_evaluator(
-        self, mocked_add_task, mocked_generator, mocked_callback, mocked_multiprocessing
+        self, mocked_add_task, mocked_callback, mocked_multiprocessing
     ):
         model = mock.Mock(spec=ema_workbench.Model)
         model.name = "test"
+        mocked_generator = mock.Mock("ema_workbench.em_framework.points.experiment_generator")
         mocked_generator.return_value = [1]
         mocked_multiprocessing.cpu_count.return_value = 4
 
         with futures_multiprocessing.MultiprocessingEvaluator(model, 2) as evaluator:
-            evaluator.evaluate_experiments(10, 10, mocked_callback)
+            evaluator.evaluate_experiments(mocked_generator, mocked_callback)
 
             mocked_add_task.assert_called_once()


### PR DESCRIPTION
This PR is the initial step for a wider overhaul of all evaluators. This PR mainly cleans up and updates the current code in line with developments in the wider python ecosystem.

* Cleanly seperate `BaseEvaluator.perform_experiments` and `BaseEvaluator.evaluate_experiments` in line with the idea in #411. So the later takes only an iterable of experiments and the callback.
* proper use of ABC stuff for BaseEvaluator
* Rewrite ad adding of tests for evaluators.py
* Adding of type hints and ruff fixes
* handling of rng for optimization

